### PR TITLE
Update CLAUDE.md with tools workflow and listing docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,9 +49,16 @@ Browser-based utilities that run entirely client-side. Tools are organized by ca
 
 ### Adding a New Tool
 1. **Create the tool** as a standalone `.html` file in `tools/` (self-contained HTML/CSS/JS, no external dependencies)
-2. **Add a list entry** in `tools/index.qmd` under the appropriate `## Category` header using the `.tool-item` div pattern (link + definition list description)
+2. **Add a list entry** in `tools/index.qmd` under the appropriate `## Category` header using the `.tool-item` div pattern (tool-link + tool-tagline + expandable tool-desc)
 3. The `.html` files are copied as-is to `_site/` via the `resources: tools/*.html` entry in `_quarto.yml`
 4. After changes, run `quarto render tools/index.qmd` to rebuild the listing (standalone HTML tools don't need rendering)
+
+### Implementation Workflow
+- When building multiple tools at once, use **parallel worktree agents** — one agent per tool in isolated worktrees, all running concurrently
+- Each agent should receive the full CSS variable set and reference file patterns to match the site theme
+- Worktree agents may not auto-commit — after they finish, **copy the generated files** from the worktree paths into the main repo and commit from there
+- Always **unhide panels before initializing canvases** — `display: none` elements have zero `clientWidth`, which breaks canvas sizing
+- After merging, clean up leftover worktrees with `git worktree remove`
 
 ### Tool Design Conventions
 - **Theme**: Must match the site's dark theme — use colors from `theme-dark.scss` (background `#1d1e20`, card `#2e2e33`, inset `#37383e`, border `#333333`, accent `#75A8D9`)
@@ -59,4 +66,4 @@ Browser-based utilities that run entirely client-side. Tools are organized by ca
 - **Back link**: Include a `← Back to Tools` link pointing to `./`
 - **Validation**: Validate input files (type, size, dimensions) with user-visible error messages
 - **Downloads**: Use blob-based downloads (`URL.createObjectURL`) instead of data URLs for large file support
-- **Listing**: Keep tool descriptions to a single line in `tools/index.qmd`
+- **Listing**: Each tool entry has a short tagline inline (no dash prefix) and a full description in an expandable `.tool-desc` div that toggles on click


### PR DESCRIPTION
## Summary
- Document the new accordion-style tool listing pattern (tool-link + tagline + expandable tool-desc)
- Add implementation workflow section covering parallel worktree agents, canvas sizing gotcha, and cleanup steps

## Test plan
- [ ] Verify CLAUDE.md renders correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)