### PR TITLE
Add shared GA tracking to tool pages

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,6 +66,7 @@ Browser-based utilities that run entirely client-side. Tools are organized by ca
 ### Tool Design Conventions
 - **Theme**: Must match the site's dark theme — use colors from `theme-dark.scss` (background `#1d1e20`, card `#2e2e33`, inset `#37383e`, border `#333333`, accent `#75A8D9`)
 - **Fonts**: Use the site's system font stack (`-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, ...`), not external fonts
+- **Analytics**: Include `<script src="analytics.js"></script>` in `<head>` (after viewport meta) — this loads shared Google Analytics tracking
 - **Back link**: Include a `← Back to Tools` link pointing to `./`
 - **Validation**: Validate input files (type, size, dimensions) with user-visible error messages
 - **Downloads**: Use blob-based downloads (`URL.createObjectURL`) instead of data URLs for large file support

--- a/_quarto.yml
+++ b/_quarto.yml
@@ -67,4 +67,5 @@ resources:
   - static
   - js
   - tools/*.html
+  - tools/analytics.js
   - CNAME

--- a/tools/analytics.js
+++ b/tools/analytics.js
@@ -1,0 +1,13 @@
+// Google Analytics — shared across all standalone tool pages
+(function() {
+  var id = 'G-16JWTLXJNG';
+  var s = document.createElement('script');
+  s.async = true;
+  s.src = 'https://www.googletagmanager.com/gtag/js?id=' + id;
+  document.head.appendChild(s);
+
+  window.dataLayer = window.dataLayer || [];
+  function gtag() { dataLayer.push(arguments); }
+  gtag('js', new Date());
+  gtag('config', id);
+})();

--- a/tools/image-converter.html
+++ b/tools/image-converter.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <script src="analytics.js"></script>
   <title>Image Format Converter — Aayush Garg</title>
   <style>
     *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }

--- a/tools/image-cropper.html
+++ b/tools/image-cropper.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <script src="analytics.js"></script>
   <title>Image Cropper — Aayush Garg</title>
   <style>
     *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }

--- a/tools/image-mask-creator.html
+++ b/tools/image-mask-creator.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <script src="analytics.js"></script>
   <title>Binary Mask Creator — Aayush Garg</title>
   <style>
     *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }

--- a/tools/image-operations.html
+++ b/tools/image-operations.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <script src="analytics.js"></script>
   <title>Image Adjust & Transform — Aayush Garg</title>
   <style>
     *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }

--- a/tools/image-resizer.html
+++ b/tools/image-resizer.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <script src="analytics.js"></script>
   <title>Image Resizer — Aayush Garg</title>
   <style>
     *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }

--- a/tools/svg-viewer.html
+++ b/tools/svg-viewer.html
@@ -3,6 +3,7 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
+<script src="analytics.js"></script>
 <title>SVG Viewer & Converter</title>
 <style>
   :root {


### PR DESCRIPTION
## Summary
- Create `tools/analytics.js` as a shared Google Analytics snippet so all standalone tool HTML pages are tracked
- Add `<script src="analytics.js"></script>` to all 6 existing tool pages
- Add `tools/analytics.js` to `_quarto.yml` resources so it gets copied to `_site/`
- Update `CLAUDE.md` tool conventions to include analytics script in future tools

## Test plan
- [ ] Verify `tools/analytics.js` loads correctly on tool pages via browser dev tools (Network tab)
- [ ] Confirm GA pageview events fire on tool page visits (GA Realtime report)

🤖 Generated with [Claude Code](https://claude.com/claude-code)