### PR TITLE
Add JSON formatter, diff viewer, and LaTeX math preview tools

### DIFF
--- a/tools/diff-viewer.html
+++ b/tools/diff-viewer.html
@@ -1,0 +1,979 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <script src="analytics.js"></script>
+    <title>Diff Viewer</title>
+    <script src="https://cdn.jsdelivr.net/npm/diff/dist/diff.min.js"></script>
+    <style>
+        :root {
+            --bg-body: #1d1e20;
+            --bg-card: #2e2e33;
+            --bg-inset: #37383e;
+            --bg-hover: #414244;
+            --border: #333333;
+            --text-primary: #dadada;
+            --text-content: #c4c4c5;
+            --text-muted: #9b9c9d;
+            --text-dim: #707073;
+            --accent: #75A8D9;
+            --accent-hover: #8fbce5;
+            --accent-dim: rgba(117, 168, 217, 0.15);
+            --green: #72994E;
+            --green-dim: rgba(114, 153, 78, 0.15);
+            --orange: #EE6331;
+            --orange-dim: rgba(238, 99, 49, 0.12);
+            --code-bg: #37383e;
+
+            --diff-added-bg: rgba(114, 153, 78, 0.18);
+            --diff-removed-bg: rgba(238, 99, 49, 0.14);
+            --diff-added-word: rgba(114, 153, 78, 0.35);
+            --diff-removed-word: rgba(238, 99, 49, 0.35);
+            --diff-empty-bg: rgba(0, 0, 0, 0.15);
+        }
+
+        * {
+            box-sizing: border-box;
+            margin: 0;
+            padding: 0;
+        }
+
+        body {
+            background: var(--bg-body);
+            color: var(--text-content);
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell, "Fira Sans", "Droid Sans", "Helvetica Neue", Arial, sans-serif;
+            padding: 24px 20px;
+            min-height: 100vh;
+        }
+
+        .container {
+            max-width: 1400px;
+            margin: 0 auto;
+        }
+
+        header {
+            text-align: center;
+            margin-bottom: 24px;
+        }
+
+        .back-link {
+            color: var(--accent);
+            text-decoration: none;
+            font-size: 14px;
+            font-weight: 500;
+            display: inline-block;
+            margin-bottom: 12px;
+            transition: color 0.15s;
+        }
+
+        .back-link:hover {
+            color: var(--accent-hover);
+        }
+
+        header h1 {
+            font-size: 22px;
+            color: var(--text-primary);
+            font-weight: 700;
+        }
+
+        .error-msg {
+            display: none;
+            background: var(--orange-dim);
+            border: 1px solid var(--orange);
+            color: var(--orange);
+            border-radius: 8px;
+            padding: 10px 14px;
+            font-size: 13px;
+            font-weight: 500;
+            margin-bottom: 16px;
+            text-align: center;
+        }
+
+        .error-msg.visible {
+            display: block;
+        }
+
+        /* Toolbar */
+        .toolbar {
+            display: flex;
+            align-items: center;
+            gap: 8px;
+            flex-wrap: wrap;
+            margin-bottom: 16px;
+        }
+
+        .toolbar-separator {
+            width: 1px;
+            height: 24px;
+            background: var(--border);
+            margin: 0 4px;
+        }
+
+        .toolbar-spacer {
+            flex: 1;
+        }
+
+        .ctrl-btn {
+            background: var(--bg-inset);
+            border: 1px solid var(--border);
+            border-radius: 6px;
+            padding: 5px 10px;
+            font-size: 12px;
+            font-weight: 500;
+            color: var(--text-content);
+            cursor: pointer;
+            transition: border-color 0.15s, background 0.15s, color 0.15s;
+            font-family: inherit;
+            white-space: nowrap;
+        }
+
+        .ctrl-btn:hover {
+            border-color: var(--accent);
+            background: var(--accent-dim);
+            color: var(--text-primary);
+        }
+
+        .ctrl-btn.active {
+            border-color: var(--accent);
+            background: var(--accent-dim);
+            color: var(--accent);
+            font-weight: 600;
+        }
+
+        .ctrl-btn.copied {
+            border-color: var(--green);
+            color: var(--green);
+            background: var(--green-dim);
+        }
+
+        .ctrl-btn.compare-btn {
+            border-color: var(--accent);
+        }
+
+        .ctrl-btn.compare-btn:hover {
+            background: var(--accent-dim);
+            color: var(--accent);
+        }
+
+        /* Input section */
+        .input-grid {
+            display: grid;
+            grid-template-columns: 1fr 1fr;
+            gap: 12px;
+            margin-bottom: 16px;
+        }
+
+        .panel {
+            background: var(--bg-card);
+            border: 1px solid var(--border);
+            border-radius: 10px;
+            padding: 16px;
+        }
+
+        .panel-label {
+            font-size: 12px;
+            font-weight: 600;
+            letter-spacing: 0.04em;
+            text-transform: uppercase;
+            color: var(--text-muted);
+            margin-bottom: 12px;
+        }
+
+        textarea {
+            width: 100%;
+            min-height: 250px;
+            background: var(--bg-inset);
+            border: 1px solid var(--border);
+            border-radius: 6px;
+            padding: 12px;
+            font-family: "SF Mono", "Fira Code", "Fira Mono", Menlo, Consolas, monospace;
+            font-size: 13px;
+            color: var(--text-content);
+            resize: vertical;
+            outline: none;
+            transition: border-color 0.15s, background 0.15s;
+            line-height: 1.5;
+        }
+
+        textarea:focus {
+            border-color: var(--accent);
+        }
+
+        textarea.drag-over {
+            border-color: var(--accent);
+            background: var(--accent-dim);
+        }
+
+        /* Diff output */
+        .diff-panel {
+            background: var(--bg-card);
+            border: 1px solid var(--border);
+            border-radius: 10px;
+            padding: 16px;
+        }
+
+        .diff-output {
+            max-height: 600px;
+            overflow-y: auto;
+            overflow-x: auto;
+            border-radius: 6px;
+            border: 1px solid var(--border);
+            background: var(--bg-inset);
+        }
+
+        .diff-output::-webkit-scrollbar {
+            width: 8px;
+            height: 8px;
+        }
+
+        .diff-output::-webkit-scrollbar-track {
+            background: var(--bg-inset);
+        }
+
+        .diff-output::-webkit-scrollbar-thumb {
+            background: var(--bg-hover);
+            border-radius: 4px;
+        }
+
+        .diff-output::-webkit-scrollbar-thumb:hover {
+            background: var(--text-dim);
+        }
+
+        /* Side-by-side diff table */
+        .diff-table {
+            width: 100%;
+            border-collapse: collapse;
+            table-layout: fixed;
+            font-family: "SF Mono", "Fira Code", "Fira Mono", Menlo, Consolas, monospace;
+            font-size: 13px;
+            line-height: 1.5;
+        }
+
+        .diff-table td {
+            padding: 0 8px;
+            vertical-align: top;
+            white-space: pre-wrap;
+            word-break: break-all;
+        }
+
+        .diff-table .line-num {
+            width: 48px;
+            min-width: 48px;
+            color: var(--text-dim);
+            text-align: right;
+            padding-right: 8px;
+            user-select: none;
+            -webkit-user-select: none;
+            border-right: 1px solid var(--border);
+        }
+
+        .diff-table .gutter {
+            width: 2px;
+            min-width: 2px;
+            max-width: 2px;
+            padding: 0;
+            background: var(--border);
+        }
+
+        .diff-table .line-content {
+            padding: 0 10px;
+        }
+
+        .diff-table .line-added {
+            background: var(--diff-added-bg);
+        }
+
+        .diff-table .line-removed {
+            background: var(--diff-removed-bg);
+        }
+
+        .diff-table .line-empty {
+            background: var(--diff-empty-bg);
+        }
+
+        .diff-table .word-added {
+            background: var(--diff-added-word);
+            border-radius: 2px;
+        }
+
+        .diff-table .word-removed {
+            background: var(--diff-removed-word);
+            border-radius: 2px;
+        }
+
+        /* Unified diff */
+        .unified-table {
+            width: 100%;
+            border-collapse: collapse;
+            table-layout: fixed;
+            font-family: "SF Mono", "Fira Code", "Fira Mono", Menlo, Consolas, monospace;
+            font-size: 13px;
+            line-height: 1.5;
+        }
+
+        .unified-table td {
+            padding: 0 8px;
+            vertical-align: top;
+            white-space: pre-wrap;
+            word-break: break-all;
+        }
+
+        .unified-table .line-num {
+            width: 48px;
+            min-width: 48px;
+            color: var(--text-dim);
+            text-align: right;
+            padding-right: 8px;
+            user-select: none;
+            -webkit-user-select: none;
+            border-right: 1px solid var(--border);
+        }
+
+        .unified-table .prefix-col {
+            width: 20px;
+            min-width: 20px;
+            text-align: center;
+            user-select: none;
+            -webkit-user-select: none;
+            color: var(--text-dim);
+        }
+
+        .unified-table .line-content {
+            padding: 0 10px;
+        }
+
+        .unified-table .line-added {
+            background: var(--diff-added-bg);
+        }
+
+        .unified-table .line-removed {
+            background: var(--diff-removed-bg);
+        }
+
+        .unified-table .word-added {
+            background: var(--diff-added-word);
+            border-radius: 2px;
+        }
+
+        .unified-table .word-removed {
+            background: var(--diff-removed-word);
+            border-radius: 2px;
+        }
+
+        /* Status bar */
+        .status-bar {
+            font-size: 12px;
+            color: var(--text-muted);
+            margin-top: 6px;
+        }
+
+        .status-additions {
+            color: var(--green);
+        }
+
+        .status-deletions {
+            color: var(--orange);
+        }
+
+        /* Empty state */
+        .diff-empty {
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            min-height: 120px;
+            color: var(--text-dim);
+            font-size: 13px;
+        }
+
+        /* Responsive */
+        @media (max-width: 768px) {
+            .input-grid {
+                grid-template-columns: 1fr;
+            }
+
+            .toolbar {
+                gap: 6px;
+            }
+
+            .toolbar-separator {
+                display: none;
+            }
+
+            .diff-table .line-num,
+            .unified-table .line-num {
+                width: 36px;
+                min-width: 36px;
+                font-size: 11px;
+            }
+        }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <header>
+            <a href="./" class="back-link">&larr; Back to Tools</a>
+            <h1>Diff Viewer</h1>
+        </header>
+
+        <div class="error-msg" id="errorMsg"></div>
+
+        <!-- Toolbar -->
+        <div class="toolbar">
+            <button class="ctrl-btn compare-btn" id="compareBtn" onclick="runDiff()">Compare</button>
+            <button class="ctrl-btn" onclick="swapTexts()">Swap</button>
+            <button class="ctrl-btn" onclick="clearAll()">Clear All</button>
+            <button class="ctrl-btn" id="copyDiffBtn" onclick="copyDiff()">Copy Diff</button>
+            <div class="toolbar-separator"></div>
+            <button class="ctrl-btn active" id="sideBySideBtn" onclick="setMode('side-by-side')">Side-by-Side</button>
+            <button class="ctrl-btn" id="unifiedBtn" onclick="setMode('unified')">Unified</button>
+        </div>
+
+        <!-- Input textareas -->
+        <div class="input-grid">
+            <div class="panel">
+                <div class="panel-label">Original</div>
+                <textarea id="originalText" placeholder="Paste or drop original text here..." spellcheck="false"></textarea>
+            </div>
+            <div class="panel">
+                <div class="panel-label">Modified</div>
+                <textarea id="modifiedText" placeholder="Paste or drop modified text here..." spellcheck="false"></textarea>
+            </div>
+        </div>
+
+        <!-- Diff output -->
+        <div class="diff-panel">
+            <div class="panel-label">Diff Output</div>
+            <div class="diff-output" id="diffOutput">
+                <div class="diff-empty">Press Compare or edit the texts above</div>
+            </div>
+            <div class="status-bar" id="statusBar"></div>
+        </div>
+    </div>
+
+    <script>
+        let currentMode = 'side-by-side';
+        let lastDiffResult = null;
+
+        // ── Sample texts ──
+        const sampleOriginal = `You are a helpful AI assistant. Answer the user's question accurately and concisely.
+
+## Instructions
+- Be direct and factual
+- If you don't know something, say so
+- Use markdown formatting when helpful
+
+## Context
+The user is asking about {topic}. Use the following reference material:
+
+{context}
+
+## User Question
+{question}
+
+Please provide a clear, well-structured answer.`;
+
+        const sampleModified = `You are a helpful AI assistant specialized in {domain}. Answer the user's question accurately, concisely, and with relevant examples.
+
+## Instructions
+- Be direct and factual
+- If you don't know something, say so clearly rather than guessing
+- Use markdown formatting when helpful
+- Include code examples when the question involves programming
+- Cite sources from the provided context when possible
+
+## Context
+The user is asking about {topic}. Use the following reference material to ground your response:
+
+{context}
+
+## Conversation History
+{history}
+
+## User Question
+{question}
+
+Please provide a clear, well-structured answer. If the question is ambiguous, ask for clarification before answering.`;
+
+        // ── Initialization ──
+        function init() {
+            const originalEl = document.getElementById('originalText');
+            const modifiedEl = document.getElementById('modifiedText');
+
+            originalEl.value = sampleOriginal;
+            modifiedEl.value = sampleModified;
+
+            setupDragDrop(originalEl);
+            setupDragDrop(modifiedEl);
+
+            // Auto-run diff after a short delay to ensure jsdiff is loaded
+            setTimeout(() => {
+                runDiff();
+            }, 100);
+        }
+
+        // ── Drag and Drop ──
+        function setupDragDrop(textarea) {
+            textarea.addEventListener('dragover', (e) => {
+                e.preventDefault();
+                e.stopPropagation();
+                textarea.classList.add('drag-over');
+            });
+
+            textarea.addEventListener('dragleave', (e) => {
+                e.preventDefault();
+                e.stopPropagation();
+                textarea.classList.remove('drag-over');
+            });
+
+            textarea.addEventListener('drop', (e) => {
+                e.preventDefault();
+                e.stopPropagation();
+                textarea.classList.remove('drag-over');
+                hideError();
+
+                const files = e.dataTransfer.files;
+                if (files.length === 0) return;
+
+                const file = files[0];
+                const maxSize = 5 * 1024 * 1024; // 5MB
+
+                if (file.size > maxSize) {
+                    showError('File exceeds 5MB limit. Please use a smaller file.');
+                    return;
+                }
+
+                // Check if it's a text file
+                if (!file.type.startsWith('text/') && !isTextExtension(file.name)) {
+                    showError('Please drop a text file.');
+                    return;
+                }
+
+                const reader = new FileReader();
+                reader.onload = (ev) => {
+                    textarea.value = ev.target.result;
+                };
+                reader.onerror = () => {
+                    showError('Failed to read file.');
+                };
+                reader.readAsText(file);
+            });
+        }
+
+        function isTextExtension(name) {
+            const textExts = ['.txt', '.md', '.json', '.xml', '.csv', '.tsv', '.yaml', '.yml',
+                '.html', '.htm', '.css', '.js', '.ts', '.py', '.java', '.c', '.cpp', '.h',
+                '.hpp', '.rs', '.go', '.rb', '.php', '.sh', '.bash', '.zsh', '.sql', '.r',
+                '.swift', '.kt', '.scala', '.lua', '.pl', '.toml', '.ini', '.cfg', '.conf',
+                '.env', '.log', '.diff', '.patch', '.qmd', '.tex', '.bib', '.svg'];
+            const ext = name.substring(name.lastIndexOf('.')).toLowerCase();
+            return textExts.includes(ext);
+        }
+
+        // ── Error handling ──
+        function showError(msg) {
+            const el = document.getElementById('errorMsg');
+            el.textContent = msg;
+            el.classList.add('visible');
+        }
+
+        function hideError() {
+            document.getElementById('errorMsg').classList.remove('visible');
+        }
+
+        // ── Mode toggle ──
+        function setMode(mode) {
+            currentMode = mode;
+            document.getElementById('sideBySideBtn').classList.toggle('active', mode === 'side-by-side');
+            document.getElementById('unifiedBtn').classList.toggle('active', mode === 'unified');
+
+            // Re-render if we have diff results
+            if (lastDiffResult) {
+                renderDiff(lastDiffResult);
+            }
+        }
+
+        // ── Main diff ──
+        function runDiff() {
+            hideError();
+
+            if (typeof Diff === 'undefined') {
+                showError('Diff library has not loaded yet. Please wait a moment and try again.');
+                return;
+            }
+
+            const original = document.getElementById('originalText').value;
+            const modified = document.getElementById('modifiedText').value;
+
+            const changes = Diff.diffLines(original, modified);
+            lastDiffResult = changes;
+            renderDiff(changes);
+        }
+
+        function renderDiff(changes) {
+            if (currentMode === 'side-by-side') {
+                renderSideBySide(changes);
+            } else {
+                renderUnified(changes);
+            }
+            renderStatus(changes);
+        }
+
+        // ── Side-by-side rendering ──
+        function renderSideBySide(changes) {
+            const container = document.getElementById('diffOutput');
+
+            // Build aligned rows
+            const rows = buildSideBySideRows(changes);
+
+            let html = '<table class="diff-table">';
+            html += '<colgroup>';
+            html += '<col style="width: 48px;">';   // left line num
+            html += '<col>';                          // left content
+            html += '<col style="width: 2px;">';      // gutter
+            html += '<col style="width: 48px;">';     // right line num
+            html += '<col>';                          // right content
+            html += '</colgroup>';
+
+            for (const row of rows) {
+                html += '<tr>';
+
+                // Left side
+                if (row.left) {
+                    const cls = row.left.type === 'removed' ? 'line-removed' : '';
+                    html += `<td class="line-num ${cls}">${row.left.lineNum}</td>`;
+                    html += `<td class="line-content ${cls}">${row.left.html}</td>`;
+                } else {
+                    html += '<td class="line-num line-empty"></td>';
+                    html += '<td class="line-content line-empty"></td>';
+                }
+
+                // Gutter
+                html += '<td class="gutter"></td>';
+
+                // Right side
+                if (row.right) {
+                    const cls = row.right.type === 'added' ? 'line-added' : '';
+                    html += `<td class="line-num ${cls}">${row.right.lineNum}</td>`;
+                    html += `<td class="line-content ${cls}">${row.right.html}</td>`;
+                } else {
+                    html += '<td class="line-num line-empty"></td>';
+                    html += '<td class="line-content line-empty"></td>';
+                }
+
+                html += '</tr>';
+            }
+
+            html += '</table>';
+            container.innerHTML = html;
+        }
+
+        function buildSideBySideRows(changes) {
+            const rows = [];
+            let leftLineNum = 1;
+            let rightLineNum = 1;
+
+            // Group changes into blocks for word-level highlighting
+            let i = 0;
+            while (i < changes.length) {
+                const change = changes[i];
+
+                if (!change.added && !change.removed) {
+                    // Unchanged block
+                    const lines = splitLines(change.value);
+                    for (const line of lines) {
+                        rows.push({
+                            left: { lineNum: leftLineNum++, html: escapeHtml(line), type: 'unchanged' },
+                            right: { lineNum: rightLineNum++, html: escapeHtml(line), type: 'unchanged' }
+                        });
+                    }
+                    i++;
+                } else if (change.removed && i + 1 < changes.length && changes[i + 1].added) {
+                    // Paired removal + addition — word-level diff
+                    const removedLines = splitLines(change.value);
+                    const addedLines = splitLines(changes[i + 1].value);
+
+                    const paired = Math.min(removedLines.length, addedLines.length);
+
+                    // Pair up lines for word-level diff
+                    for (let j = 0; j < paired; j++) {
+                        const wordDiff = Diff.diffWords(removedLines[j], addedLines[j]);
+                        let leftHtml = '';
+                        let rightHtml = '';
+
+                        for (const part of wordDiff) {
+                            const escaped = escapeHtml(part.value);
+                            if (part.removed) {
+                                leftHtml += `<span class="word-removed">${escaped}</span>`;
+                            } else if (part.added) {
+                                rightHtml += `<span class="word-added">${escaped}</span>`;
+                            } else {
+                                leftHtml += escaped;
+                                rightHtml += escaped;
+                            }
+                        }
+
+                        rows.push({
+                            left: { lineNum: leftLineNum++, html: leftHtml, type: 'removed' },
+                            right: { lineNum: rightLineNum++, html: rightHtml, type: 'added' }
+                        });
+                    }
+
+                    // Remaining removed lines (more removals than additions)
+                    for (let j = paired; j < removedLines.length; j++) {
+                        rows.push({
+                            left: { lineNum: leftLineNum++, html: escapeHtml(removedLines[j]), type: 'removed' },
+                            right: null
+                        });
+                    }
+
+                    // Remaining added lines (more additions than removals)
+                    for (let j = paired; j < addedLines.length; j++) {
+                        rows.push({
+                            left: null,
+                            right: { lineNum: rightLineNum++, html: escapeHtml(addedLines[j]), type: 'added' }
+                        });
+                    }
+
+                    i += 2;
+                } else if (change.removed) {
+                    // Removal only
+                    const lines = splitLines(change.value);
+                    for (const line of lines) {
+                        rows.push({
+                            left: { lineNum: leftLineNum++, html: escapeHtml(line), type: 'removed' },
+                            right: null
+                        });
+                    }
+                    i++;
+                } else if (change.added) {
+                    // Addition only
+                    const lines = splitLines(change.value);
+                    for (const line of lines) {
+                        rows.push({
+                            left: null,
+                            right: { lineNum: rightLineNum++, html: escapeHtml(line), type: 'added' }
+                        });
+                    }
+                    i++;
+                } else {
+                    i++;
+                }
+            }
+
+            return rows;
+        }
+
+        // ── Unified rendering ──
+        function renderUnified(changes) {
+            const container = document.getElementById('diffOutput');
+
+            let html = '<table class="unified-table">';
+            html += '<colgroup>';
+            html += '<col style="width: 48px;">';   // left line num
+            html += '<col style="width: 48px;">';   // right line num
+            html += '<col style="width: 20px;">';    // prefix
+            html += '<col>';                          // content
+            html += '</colgroup>';
+
+            let leftLineNum = 1;
+            let rightLineNum = 1;
+
+            let i = 0;
+            while (i < changes.length) {
+                const change = changes[i];
+
+                if (!change.added && !change.removed) {
+                    // Unchanged
+                    const lines = splitLines(change.value);
+                    for (const line of lines) {
+                        html += '<tr>';
+                        html += `<td class="line-num">${leftLineNum++}</td>`;
+                        html += `<td class="line-num">${rightLineNum++}</td>`;
+                        html += '<td class="prefix-col"> </td>';
+                        html += `<td class="line-content">${escapeHtml(line)}</td>`;
+                        html += '</tr>';
+                    }
+                    i++;
+                } else if (change.removed && i + 1 < changes.length && changes[i + 1].added) {
+                    // Paired removal + addition — word-level diff
+                    const removedLines = splitLines(change.value);
+                    const addedLines = splitLines(changes[i + 1].value);
+
+                    const paired = Math.min(removedLines.length, addedLines.length);
+
+                    // Build word-diffed HTML for paired lines
+                    const removedHtmls = [];
+                    const addedHtmls = [];
+
+                    for (let j = 0; j < paired; j++) {
+                        const wordDiff = Diff.diffWords(removedLines[j], addedLines[j]);
+                        let leftHtml = '';
+                        let rightHtml = '';
+
+                        for (const part of wordDiff) {
+                            const escaped = escapeHtml(part.value);
+                            if (part.removed) {
+                                leftHtml += `<span class="word-removed">${escaped}</span>`;
+                            } else if (part.added) {
+                                rightHtml += `<span class="word-added">${escaped}</span>`;
+                            } else {
+                                leftHtml += escaped;
+                                rightHtml += escaped;
+                            }
+                        }
+
+                        removedHtmls.push(leftHtml);
+                        addedHtmls.push(rightHtml);
+                    }
+
+                    // Render all removed lines first
+                    for (let j = 0; j < removedLines.length; j++) {
+                        const content = j < paired ? removedHtmls[j] : escapeHtml(removedLines[j]);
+                        html += `<tr class="line-removed">`;
+                        html += `<td class="line-num line-removed">${leftLineNum++}</td>`;
+                        html += '<td class="line-num line-removed"></td>';
+                        html += '<td class="prefix-col line-removed">-</td>';
+                        html += `<td class="line-content line-removed">${content}</td>`;
+                        html += '</tr>';
+                    }
+
+                    // Then all added lines
+                    for (let j = 0; j < addedLines.length; j++) {
+                        const content = j < paired ? addedHtmls[j] : escapeHtml(addedLines[j]);
+                        html += `<tr class="line-added">`;
+                        html += '<td class="line-num line-added"></td>';
+                        html += `<td class="line-num line-added">${rightLineNum++}</td>`;
+                        html += '<td class="prefix-col line-added">+</td>';
+                        html += `<td class="line-content line-added">${content}</td>`;
+                        html += '</tr>';
+                    }
+
+                    i += 2;
+                } else if (change.removed) {
+                    const lines = splitLines(change.value);
+                    for (const line of lines) {
+                        html += `<tr class="line-removed">`;
+                        html += `<td class="line-num line-removed">${leftLineNum++}</td>`;
+                        html += '<td class="line-num line-removed"></td>';
+                        html += '<td class="prefix-col line-removed">-</td>';
+                        html += `<td class="line-content line-removed">${escapeHtml(line)}</td>`;
+                        html += '</tr>';
+                    }
+                    i++;
+                } else if (change.added) {
+                    const lines = splitLines(change.value);
+                    for (const line of lines) {
+                        html += `<tr class="line-added">`;
+                        html += '<td class="line-num line-added"></td>';
+                        html += `<td class="line-num line-added">${rightLineNum++}</td>`;
+                        html += '<td class="prefix-col line-added">+</td>';
+                        html += `<td class="line-content line-added">${escapeHtml(line)}</td>`;
+                        html += '</tr>';
+                    }
+                    i++;
+                } else {
+                    i++;
+                }
+            }
+
+            html += '</table>';
+            container.innerHTML = html;
+        }
+
+        // ── Status bar ──
+        function renderStatus(changes) {
+            let additions = 0;
+            let deletions = 0;
+            let unchanged = 0;
+
+            for (const change of changes) {
+                const lineCount = splitLines(change.value).length;
+                if (change.added) {
+                    additions += lineCount;
+                } else if (change.removed) {
+                    deletions += lineCount;
+                } else {
+                    unchanged += lineCount;
+                }
+            }
+
+            const statusEl = document.getElementById('statusBar');
+            statusEl.innerHTML = `<span class="status-additions">+${additions} addition${additions !== 1 ? 's' : ''}</span>, <span class="status-deletions">-${deletions} deletion${deletions !== 1 ? 's' : ''}</span>, ${unchanged} unchanged`;
+        }
+
+        // ── Swap ──
+        function swapTexts() {
+            const originalEl = document.getElementById('originalText');
+            const modifiedEl = document.getElementById('modifiedText');
+            const tmp = originalEl.value;
+            originalEl.value = modifiedEl.value;
+            modifiedEl.value = tmp;
+
+            // Re-run diff if we had results
+            if (lastDiffResult) {
+                runDiff();
+            }
+        }
+
+        // ── Clear All ──
+        function clearAll() {
+            document.getElementById('originalText').value = '';
+            document.getElementById('modifiedText').value = '';
+            document.getElementById('diffOutput').innerHTML = '<div class="diff-empty">Press Compare or edit the texts above</div>';
+            document.getElementById('statusBar').innerHTML = '';
+            lastDiffResult = null;
+            hideError();
+        }
+
+        // ── Copy Diff ──
+        function copyDiff() {
+            hideError();
+
+            if (typeof Diff === 'undefined') {
+                showError('Diff library has not loaded yet. Please wait a moment and try again.');
+                return;
+            }
+
+            const original = document.getElementById('originalText').value;
+            const modified = document.getElementById('modifiedText').value;
+
+            const patch = Diff.createTwoFilesPatch('original', 'modified', original, modified);
+
+            navigator.clipboard.writeText(patch).then(() => {
+                const btn = document.getElementById('copyDiffBtn');
+                const originalText = btn.textContent;
+                btn.textContent = 'Copied!';
+                btn.classList.add('copied');
+                setTimeout(() => {
+                    btn.textContent = originalText;
+                    btn.classList.remove('copied');
+                }, 1500);
+            }).catch(() => {
+                showError('Failed to copy to clipboard.');
+            });
+        }
+
+        // ── Utilities ──
+        function escapeHtml(text) {
+            const div = document.createElement('div');
+            div.textContent = text;
+            return div.innerHTML;
+        }
+
+        function splitLines(text) {
+            // Split text into lines, handling trailing newline
+            if (text === '') return [''];
+            const lines = text.split('\n');
+            // jsdiff includes trailing newline in value — remove the empty last element
+            if (lines.length > 0 && lines[lines.length - 1] === '') {
+                lines.pop();
+            }
+            return lines.length === 0 ? [''] : lines;
+        }
+
+        // ── Start ──
+        document.addEventListener('DOMContentLoaded', init);
+    </script>
+</body>
+</html>

--- a/tools/index.qmd
+++ b/tools/index.qmd
@@ -81,6 +81,30 @@ Paste or drop Markdown for live GFM-rendered preview with syntax-highlighted cod
 :::
 :::
 
+::: {.tool-item}
+[JSON Formatter & Viewer](json-formatter.html){.tool-link} [format, validate, and explore JSON]{.tool-tagline}
+
+::: {.tool-desc}
+Paste or drop JSON to format with syntax highlighting, collapsible tree view, validation with line-level error reporting, search, and one-click copy.
+:::
+:::
+
+::: {.tool-item}
+[Diff Viewer](diff-viewer.html){.tool-link} [compare text side-by-side with word-level highlighting]{.tool-tagline}
+
+::: {.tool-desc}
+Compare two text blocks with line-level and word-level diff highlighting. Side-by-side and unified diff modes. Requires internet for diff library.
+:::
+:::
+
+::: {.tool-item}
+[LaTeX Math Preview](latex-preview.html){.tool-link} [scratchpad for previewing LaTeX equations]{.tool-tagline}
+
+::: {.tool-desc}
+Type LaTeX and see it rendered instantly with KaTeX. Per-equation error feedback, symbol palette, render mode toggle, and saved snippets. Requires internet for KaTeX.
+:::
+:::
+
 :::
 
 ::: {.template-credit}

--- a/tools/json-formatter.html
+++ b/tools/json-formatter.html
@@ -1,0 +1,1275 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <script src="analytics.js"></script>
+    <title>JSON Formatter & Viewer</title>
+    <style>
+        :root {
+            --bg-body: #1d1e20;
+            --bg-card: #2e2e33;
+            --bg-inset: #37383e;
+            --bg-hover: #414244;
+            --border: #333333;
+            --text-primary: #dadada;
+            --text-content: #c4c4c5;
+            --text-muted: #9b9c9d;
+            --text-dim: #707073;
+            --accent: #75A8D9;
+            --accent-hover: #8fbce5;
+            --accent-dim: rgba(117, 168, 217, 0.15);
+            --green: #72994E;
+            --green-dim: rgba(114, 153, 78, 0.15);
+            --orange: #EE6331;
+            --orange-dim: rgba(238, 99, 49, 0.12);
+            --code-bg: #37383e;
+
+            --syn-key: #75A8D9;
+            --syn-string: #C3E88D;
+            --syn-number: #F78C6C;
+            --syn-boolean: #C792EA;
+            --syn-null: #FF5370;
+            --syn-brace: #9b9c9d;
+            --search-highlight: rgba(255, 213, 79, 0.35);
+            --search-active: rgba(255, 213, 79, 0.7);
+        }
+
+        * {
+            box-sizing: border-box;
+            margin: 0;
+            padding: 0;
+        }
+
+        body {
+            background: var(--bg-body);
+            color: var(--text-content);
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell, "Fira Sans", "Droid Sans", "Helvetica Neue", Arial, sans-serif;
+            padding: 24px 20px;
+            min-height: 100vh;
+        }
+
+        .container {
+            max-width: 1400px;
+            margin: 0 auto;
+        }
+
+        header {
+            text-align: center;
+            margin-bottom: 24px;
+        }
+
+        .back-link {
+            color: var(--accent);
+            text-decoration: none;
+            font-size: 14px;
+            font-weight: 500;
+            display: inline-block;
+            margin-bottom: 12px;
+            transition: color 0.15s;
+        }
+
+        .back-link:hover {
+            color: var(--accent-hover);
+        }
+
+        header h1 {
+            font-size: 22px;
+            color: var(--text-primary);
+            font-weight: 700;
+        }
+
+        .error-msg {
+            display: none;
+            background: var(--orange-dim);
+            border: 1px solid var(--orange);
+            color: var(--orange);
+            border-radius: 8px;
+            padding: 10px 14px;
+            font-size: 13px;
+            margin-bottom: 12px;
+        }
+
+        .error-msg.visible {
+            display: block;
+        }
+
+        .split-pane {
+            display: grid;
+            grid-template-columns: 1fr 1.5fr;
+            gap: 12px;
+        }
+
+        @media (max-width: 768px) {
+            .split-pane {
+                grid-template-columns: 1fr;
+            }
+        }
+
+        .panel {
+            background: var(--bg-card);
+            border: 1px solid var(--border);
+            border-radius: 10px;
+            padding: 16px;
+            display: flex;
+            flex-direction: column;
+        }
+
+        .panel-label {
+            font-size: 12px;
+            font-weight: 600;
+            letter-spacing: 0.04em;
+            text-transform: uppercase;
+            color: var(--text-muted);
+            margin-bottom: 8px;
+        }
+
+        .toolbar {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 6px;
+            margin-bottom: 10px;
+        }
+
+        .ctrl-btn {
+            background: var(--bg-inset);
+            border: 1px solid var(--border);
+            border-radius: 6px;
+            padding: 5px 10px;
+            font-size: 12px;
+            color: var(--text-content);
+            cursor: pointer;
+            font-family: inherit;
+            transition: border-color 0.15s, background 0.15s, color 0.15s;
+            white-space: nowrap;
+        }
+
+        .ctrl-btn:hover {
+            border-color: var(--accent);
+            background: var(--accent-dim);
+        }
+
+        .ctrl-btn.active {
+            border-color: var(--accent);
+            background: var(--accent-dim);
+            color: var(--accent);
+        }
+
+        .ctrl-btn.copied {
+            border-color: var(--green);
+            color: var(--green);
+            background: var(--green-dim);
+        }
+
+        #jsonInput {
+            background: var(--bg-inset);
+            border: 1px solid var(--border);
+            border-radius: 6px;
+            padding: 12px;
+            font-family: "SF Mono", "Fira Code", "Fira Mono", Menlo, Consolas, monospace;
+            font-size: 13px;
+            color: var(--text-content);
+            min-height: 600px;
+            flex: 1;
+            resize: vertical;
+            outline: none;
+            transition: border-color 0.15s, background 0.15s;
+            line-height: 1.5;
+            tab-size: 4;
+        }
+
+        #jsonInput:focus {
+            border-color: var(--accent);
+        }
+
+        #jsonInput.drag-over {
+            border-color: var(--accent);
+            background: var(--accent-dim);
+        }
+
+        .status-bar {
+            font-size: 12px;
+            color: var(--text-muted);
+            margin-top: 6px;
+            display: flex;
+            gap: 12px;
+            flex-wrap: wrap;
+        }
+
+        .status-bar .valid {
+            color: var(--green);
+        }
+
+        .status-bar .invalid {
+            color: var(--orange);
+        }
+
+        .search-bar {
+            display: flex;
+            gap: 6px;
+            margin-bottom: 10px;
+            align-items: center;
+        }
+
+        .search-bar input {
+            flex: 1;
+            background: var(--bg-inset);
+            border: 1px solid var(--border);
+            border-radius: 6px;
+            padding: 5px 10px;
+            font-size: 12px;
+            color: var(--text-content);
+            font-family: inherit;
+            outline: none;
+            transition: border-color 0.15s;
+        }
+
+        .search-bar input:focus {
+            border-color: var(--accent);
+        }
+
+        .search-bar .search-info {
+            font-size: 12px;
+            color: var(--text-muted);
+            white-space: nowrap;
+        }
+
+        .search-nav-btn {
+            background: var(--bg-inset);
+            border: 1px solid var(--border);
+            border-radius: 6px;
+            padding: 3px 8px;
+            font-size: 12px;
+            color: var(--text-content);
+            cursor: pointer;
+            font-family: inherit;
+            transition: border-color 0.15s, background 0.15s;
+            line-height: 1;
+        }
+
+        .search-nav-btn:hover {
+            border-color: var(--accent);
+            background: var(--accent-dim);
+        }
+
+        #treeView {
+            background: var(--bg-inset);
+            border: 1px solid var(--border);
+            border-radius: 6px;
+            padding: 12px;
+            font-family: "SF Mono", "Fira Code", "Fira Mono", Menlo, Consolas, monospace;
+            font-size: 13px;
+            min-height: 600px;
+            max-height: 800px;
+            overflow-y: auto;
+            overflow-x: auto;
+            flex: 1;
+            line-height: 1.6;
+            scrollbar-color: var(--bg-hover) var(--bg-inset);
+        }
+
+        #treeView::-webkit-scrollbar {
+            width: 8px;
+            height: 8px;
+        }
+
+        #treeView::-webkit-scrollbar-track {
+            background: var(--bg-inset);
+        }
+
+        #treeView::-webkit-scrollbar-thumb {
+            background: var(--bg-hover);
+            border-radius: 4px;
+        }
+
+        .tree-line {
+            white-space: nowrap;
+        }
+
+        .tree-toggle {
+            cursor: pointer;
+            user-select: none;
+            display: inline-block;
+            width: 16px;
+            text-align: center;
+            color: var(--text-dim);
+            transition: color 0.15s;
+        }
+
+        .tree-toggle:hover {
+            color: var(--text-primary);
+        }
+
+        .tree-key {
+            color: var(--syn-key);
+        }
+
+        .tree-string {
+            color: var(--syn-string);
+        }
+
+        .tree-number {
+            color: var(--syn-number);
+        }
+
+        .tree-boolean {
+            color: var(--syn-boolean);
+        }
+
+        .tree-null {
+            color: var(--syn-null);
+        }
+
+        .tree-brace {
+            color: var(--syn-brace);
+        }
+
+        .tree-comma {
+            color: var(--syn-brace);
+        }
+
+        .tree-colon {
+            color: var(--syn-brace);
+        }
+
+        .tree-summary {
+            color: var(--text-dim);
+            font-style: italic;
+        }
+
+        .tree-children {
+            padding-left: 20px;
+        }
+
+        .tree-children.collapsed {
+            display: none;
+        }
+
+        .search-match {
+            background: var(--search-highlight);
+            border-radius: 2px;
+        }
+
+        .search-match-active {
+            background: var(--search-active);
+            border-radius: 2px;
+        }
+
+        .empty-state {
+            color: var(--text-dim);
+            font-style: italic;
+            padding: 20px;
+            text-align: center;
+        }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <header>
+            <a href="./" class="back-link">&larr; Back to Tools</a>
+            <h1>JSON Formatter & Viewer</h1>
+        </header>
+
+        <div id="errorMsg" class="error-msg"></div>
+
+        <div class="split-pane">
+            <div class="panel">
+                <div class="panel-label">Input</div>
+                <div class="toolbar">
+                    <button class="ctrl-btn" id="btnFormat" title="Pretty-print JSON">Format</button>
+                    <button class="ctrl-btn" id="btnMinify" title="Minify JSON">Minify</button>
+                    <button class="ctrl-btn" id="btnClear" title="Clear input">Clear</button>
+                    <button class="ctrl-btn" id="btnIndent" title="Toggle indent size">4 spaces</button>
+                </div>
+                <textarea id="jsonInput" spellcheck="false" placeholder="Paste JSON here or drop a .json file..."></textarea>
+                <div class="status-bar">
+                    <span id="statusChars">0 chars</span>
+                    <span id="statusLines">0 lines</span>
+                    <span id="statusValid"></span>
+                </div>
+            </div>
+
+            <div class="panel">
+                <div class="panel-label">Formatted</div>
+                <div class="toolbar">
+                    <button class="ctrl-btn" id="btnCopyFormatted" title="Copy formatted JSON">Copy Formatted</button>
+                    <button class="ctrl-btn" id="btnCopyMinified" title="Copy minified JSON">Copy Minified</button>
+                    <button class="ctrl-btn" id="btnExpandAll" title="Expand all nodes">Expand All</button>
+                    <button class="ctrl-btn" id="btnCollapseAll" title="Collapse all nodes">Collapse All</button>
+                </div>
+                <div class="search-bar">
+                    <input type="text" id="searchInput" placeholder="Search keys and values...">
+                    <span class="search-info" id="searchInfo"></span>
+                    <button class="search-nav-btn" id="btnSearchPrev" title="Previous match">&#9650;</button>
+                    <button class="search-nav-btn" id="btnSearchNext" title="Next match">&#9660;</button>
+                </div>
+                <div id="treeView">
+                    <div class="empty-state">Paste or drop JSON to get started</div>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <script>
+    (function() {
+        'use strict';
+
+        // --- State ---
+        var indentSize = 4;
+        var parsedJSON = null;
+        var isValid = false;
+        var debounceTimer = null;
+        var searchMatches = [];
+        var currentMatchIndex = -1;
+
+        // --- DOM refs ---
+        var jsonInput = document.getElementById('jsonInput');
+        var treeView = document.getElementById('treeView');
+        var errorMsg = document.getElementById('errorMsg');
+        var statusChars = document.getElementById('statusChars');
+        var statusLines = document.getElementById('statusLines');
+        var statusValid = document.getElementById('statusValid');
+        var searchInput = document.getElementById('searchInput');
+        var searchInfo = document.getElementById('searchInfo');
+        var btnFormat = document.getElementById('btnFormat');
+        var btnMinify = document.getElementById('btnMinify');
+        var btnClear = document.getElementById('btnClear');
+        var btnIndent = document.getElementById('btnIndent');
+        var btnCopyFormatted = document.getElementById('btnCopyFormatted');
+        var btnCopyMinified = document.getElementById('btnCopyMinified');
+        var btnExpandAll = document.getElementById('btnExpandAll');
+        var btnCollapseAll = document.getElementById('btnCollapseAll');
+        var btnSearchPrev = document.getElementById('btnSearchPrev');
+        var btnSearchNext = document.getElementById('btnSearchNext');
+
+        // --- Sample JSON ---
+        var sampleJSON = {
+            "model": {
+                "name": "llama-3.1-8b-instruct",
+                "architecture": "transformer",
+                "parameters": "8B",
+                "context_length": 131072,
+                "vocab_size": 128256
+            },
+            "training": {
+                "method": "LoRA",
+                "config": {
+                    "r": 16,
+                    "lora_alpha": 32,
+                    "lora_dropout": 0.05,
+                    "target_modules": ["q_proj", "v_proj", "k_proj", "o_proj"],
+                    "bias": "none"
+                },
+                "hyperparameters": {
+                    "learning_rate": 2e-4,
+                    "batch_size": 8,
+                    "gradient_accumulation_steps": 4,
+                    "epochs": 3,
+                    "warmup_ratio": 0.03,
+                    "weight_decay": 0.01,
+                    "max_grad_norm": 1.0,
+                    "lr_scheduler": "cosine",
+                    "bf16": true
+                },
+                "dataset": {
+                    "name": "custom-instruction-following",
+                    "train_samples": 52000,
+                    "eval_samples": 2600,
+                    "max_seq_length": 4096
+                }
+            },
+            "evaluation": {
+                "mmlu": { "score": 0.687, "category": "knowledge" },
+                "humaneval": { "pass@1": 0.524, "pass@10": 0.789, "category": "coding" },
+                "gsm8k": { "score": 0.731, "category": "math" },
+                "truthfulqa": { "score": 0.612, "category": "safety" },
+                "overall_rank": 42,
+                "evaluated_on": "2025-01-15"
+            },
+            "deployment": {
+                "framework": "vllm",
+                "quantization": "awq-4bit",
+                "gpu_memory_gb": 6.2,
+                "max_throughput_tok_s": 2400,
+                "api_endpoint": null,
+                "active": true
+            }
+        };
+
+        // --- Initialize ---
+        jsonInput.value = JSON.stringify(sampleJSON, null, indentSize);
+        processInput();
+
+        // --- Input handling ---
+        jsonInput.addEventListener('input', function() {
+            clearTimeout(debounceTimer);
+            debounceTimer = setTimeout(processInput, 300);
+        });
+
+        // Tab key support in textarea
+        jsonInput.addEventListener('keydown', function(e) {
+            if (e.key === 'Tab') {
+                e.preventDefault();
+                var start = this.selectionStart;
+                var end = this.selectionEnd;
+                var spaces = ' '.repeat(indentSize);
+                this.value = this.value.substring(0, start) + spaces + this.value.substring(end);
+                this.selectionStart = this.selectionEnd = start + indentSize;
+                clearTimeout(debounceTimer);
+                debounceTimer = setTimeout(processInput, 300);
+            }
+        });
+
+        // --- Drag and drop ---
+        jsonInput.addEventListener('dragover', function(e) {
+            e.preventDefault();
+            e.stopPropagation();
+            jsonInput.classList.add('drag-over');
+        });
+
+        jsonInput.addEventListener('dragleave', function(e) {
+            e.preventDefault();
+            e.stopPropagation();
+            jsonInput.classList.remove('drag-over');
+        });
+
+        jsonInput.addEventListener('drop', function(e) {
+            e.preventDefault();
+            e.stopPropagation();
+            jsonInput.classList.remove('drag-over');
+
+            var files = e.dataTransfer.files;
+            if (files.length === 0) return;
+
+            var file = files[0];
+            var validTypes = ['application/json', 'text/plain', 'text/json'];
+            var validExt = file.name.match(/\.(json|txt)$/i);
+
+            if (!validTypes.includes(file.type) && !validExt) {
+                showError('Please drop a .json or .txt file.');
+                return;
+            }
+
+            if (file.size > 5 * 1024 * 1024) {
+                showError('File too large. Maximum size is 5MB.');
+                return;
+            }
+
+            var reader = new FileReader();
+            reader.onload = function(ev) {
+                jsonInput.value = ev.target.result;
+                hideError();
+                processInput();
+            };
+            reader.onerror = function() {
+                showError('Failed to read file.');
+            };
+            reader.readAsText(file);
+        });
+
+        // --- Toolbar buttons ---
+        btnFormat.addEventListener('click', function() {
+            if (!isValid || parsedJSON === undefined) return;
+            jsonInput.value = JSON.stringify(parsedJSON, null, indentSize);
+            processInput();
+        });
+
+        btnMinify.addEventListener('click', function() {
+            if (!isValid || parsedJSON === undefined) return;
+            jsonInput.value = JSON.stringify(parsedJSON);
+            processInput();
+        });
+
+        btnClear.addEventListener('click', function() {
+            jsonInput.value = '';
+            processInput();
+        });
+
+        btnIndent.addEventListener('click', function() {
+            if (indentSize === 4) {
+                indentSize = 2;
+                btnIndent.textContent = '2 spaces';
+            } else {
+                indentSize = 4;
+                btnIndent.textContent = '4 spaces';
+            }
+            btnIndent.classList.add('active');
+            setTimeout(function() { btnIndent.classList.remove('active'); }, 200);
+            if (isValid && parsedJSON !== undefined) {
+                renderTree(parsedJSON);
+                applySearch();
+            }
+        });
+
+        btnCopyFormatted.addEventListener('click', function() {
+            if (!isValid || parsedJSON === undefined) return;
+            copyToClipboard(JSON.stringify(parsedJSON, null, indentSize), btnCopyFormatted);
+        });
+
+        btnCopyMinified.addEventListener('click', function() {
+            if (!isValid || parsedJSON === undefined) return;
+            copyToClipboard(JSON.stringify(parsedJSON), btnCopyMinified);
+        });
+
+        btnExpandAll.addEventListener('click', function() {
+            var containers = treeView.querySelectorAll('.tree-children');
+            for (var i = 0; i < containers.length; i++) {
+                containers[i].classList.remove('collapsed');
+                // Show the closing brace/bracket line (next sibling of tree-children)
+                var closeLine = containers[i].nextElementSibling;
+                if (closeLine) closeLine.style.display = '';
+            }
+            var toggles = treeView.querySelectorAll('.tree-toggle');
+            for (var j = 0; j < toggles.length; j++) {
+                toggles[j].textContent = '\u25BC';
+            }
+            // Hide summaries
+            var summaries = treeView.querySelectorAll('.tree-summary');
+            for (var k = 0; k < summaries.length; k++) {
+                summaries[k].style.display = 'none';
+            }
+        });
+
+        btnCollapseAll.addEventListener('click', function() {
+            var containers = treeView.querySelectorAll('.tree-children');
+            for (var i = 0; i < containers.length; i++) {
+                containers[i].classList.add('collapsed');
+                // Hide the closing brace/bracket line (next sibling of tree-children)
+                var closeLine = containers[i].nextElementSibling;
+                if (closeLine) closeLine.style.display = 'none';
+            }
+            var toggles = treeView.querySelectorAll('.tree-toggle');
+            for (var j = 0; j < toggles.length; j++) {
+                toggles[j].textContent = '\u25B6';
+            }
+            // Show summaries
+            var summaries = treeView.querySelectorAll('.tree-summary');
+            for (var k = 0; k < summaries.length; k++) {
+                summaries[k].style.display = '';
+            }
+        });
+
+        // --- Search ---
+        var searchDebounce = null;
+        searchInput.addEventListener('input', function() {
+            clearTimeout(searchDebounce);
+            searchDebounce = setTimeout(applySearch, 200);
+        });
+
+        searchInput.addEventListener('keydown', function(e) {
+            if (e.key === 'Enter') {
+                e.preventDefault();
+                if (e.shiftKey) {
+                    navigateMatch(-1);
+                } else {
+                    navigateMatch(1);
+                }
+            }
+        });
+
+        btnSearchPrev.addEventListener('click', function() {
+            navigateMatch(-1);
+        });
+
+        btnSearchNext.addEventListener('click', function() {
+            navigateMatch(1);
+        });
+
+        // --- Core functions ---
+
+        function processInput() {
+            var text = jsonInput.value;
+            updateStatus(text);
+
+            if (text.trim() === '') {
+                parsedJSON = undefined;
+                isValid = false;
+                statusValid.textContent = '';
+                statusValid.className = '';
+                treeView.innerHTML = '';
+                var empty = document.createElement('div');
+                empty.className = 'empty-state';
+                empty.textContent = 'Paste or drop JSON to get started';
+                treeView.appendChild(empty);
+                hideError();
+                clearSearch();
+                return;
+            }
+
+            try {
+                parsedJSON = JSON.parse(text);
+                isValid = true;
+                statusValid.textContent = 'Valid JSON';
+                statusValid.className = 'valid';
+                hideError();
+                renderTree(parsedJSON);
+                applySearch();
+            } catch (e) {
+                isValid = false;
+                parsedJSON = undefined;
+                var errInfo = parseErrorPosition(e.message, text);
+                if (errInfo.line > 0) {
+                    statusValid.textContent = 'Invalid \u2014 line ' + errInfo.line + ', col ' + errInfo.col;
+                } else {
+                    statusValid.textContent = 'Invalid JSON';
+                }
+                statusValid.className = 'invalid';
+                treeView.innerHTML = '';
+                var errDiv = document.createElement('div');
+                errDiv.className = 'empty-state';
+                errDiv.style.color = 'var(--orange)';
+                errDiv.textContent = e.message;
+                treeView.appendChild(errDiv);
+                clearSearch();
+            }
+        }
+
+        function updateStatus(text) {
+            var chars = text.length;
+            var lines = text === '' ? 0 : text.split('\n').length;
+            statusChars.textContent = chars.toLocaleString() + ' char' + (chars !== 1 ? 's' : '');
+            statusLines.textContent = lines.toLocaleString() + ' line' + (lines !== 1 ? 's' : '');
+        }
+
+        function parseErrorPosition(message, text) {
+            // Try to extract position from error message
+            // Chrome: "... at position 123"
+            // Firefox: "... at line X column Y"
+            var result = { line: 0, col: 0 };
+
+            var posMatch = message.match(/at position (\d+)/i);
+            if (posMatch) {
+                var pos = parseInt(posMatch[1], 10);
+                var upToPos = text.substring(0, pos);
+                var linesSplit = upToPos.split('\n');
+                result.line = linesSplit.length;
+                result.col = linesSplit[linesSplit.length - 1].length + 1;
+                return result;
+            }
+
+            var lineColMatch = message.match(/line (\d+) column (\d+)/i);
+            if (lineColMatch) {
+                result.line = parseInt(lineColMatch[1], 10);
+                result.col = parseInt(lineColMatch[2], 10);
+                return result;
+            }
+
+            return result;
+        }
+
+        // --- Tree rendering ---
+
+        function renderTree(data) {
+            treeView.innerHTML = '';
+            var fragment = document.createDocumentFragment();
+            buildNode(fragment, data, false, true);
+            treeView.appendChild(fragment);
+        }
+
+        function buildNode(parent, value, addComma, isLast) {
+            if (value === null) {
+                var line = createLine();
+                appendText(line, 'null', 'tree-null');
+                if (!isLast) appendComma(line);
+                parent.appendChild(line);
+            } else if (typeof value === 'boolean') {
+                var line = createLine();
+                appendText(line, String(value), 'tree-boolean');
+                if (!isLast) appendComma(line);
+                parent.appendChild(line);
+            } else if (typeof value === 'number') {
+                var line = createLine();
+                appendText(line, String(value), 'tree-number');
+                if (!isLast) appendComma(line);
+                parent.appendChild(line);
+            } else if (typeof value === 'string') {
+                var line = createLine();
+                appendText(line, '"' + escapeString(value) + '"', 'tree-string');
+                if (!isLast) appendComma(line);
+                parent.appendChild(line);
+            } else if (Array.isArray(value)) {
+                buildArrayNode(parent, value, isLast);
+            } else if (typeof value === 'object') {
+                buildObjectNode(parent, value, isLast);
+            }
+        }
+
+        function buildObjectNode(parent, obj, isLast) {
+            var keys = Object.keys(obj);
+            var count = keys.length;
+
+            if (count === 0) {
+                var line = createLine();
+                appendText(line, '{}', 'tree-brace');
+                if (!isLast) appendComma(line);
+                parent.appendChild(line);
+                return;
+            }
+
+            // Opening line with toggle
+            var openLine = createLine();
+            var toggle = document.createElement('span');
+            toggle.className = 'tree-toggle';
+            toggle.textContent = '\u25BC';
+            openLine.appendChild(toggle);
+            appendText(openLine, ' {', 'tree-brace');
+
+            // Summary (hidden when expanded)
+            var summary = document.createElement('span');
+            summary.className = 'tree-summary';
+            summary.textContent = ' {...} (' + count + ' key' + (count !== 1 ? 's' : '') + ')';
+            summary.style.display = 'none';
+            openLine.appendChild(summary);
+
+            if (!isLast) {
+                // Comma after closing brace will be added at close line
+            }
+
+            parent.appendChild(openLine);
+
+            // Children container
+            var children = document.createElement('div');
+            children.className = 'tree-children';
+
+            for (var i = 0; i < keys.length; i++) {
+                var key = keys[i];
+                var val = obj[key];
+                var entryIsLast = (i === keys.length - 1);
+
+                if (val !== null && typeof val === 'object') {
+                    // Compound value: key on same line as opening brace
+                    buildCompoundEntry(children, key, val, entryIsLast);
+                } else {
+                    // Primitive value: key: value on one line
+                    var kvLine = createLine();
+                    appendText(kvLine, '"' + escapeString(key) + '"', 'tree-key');
+                    appendText(kvLine, ': ', 'tree-colon');
+                    appendPrimitive(kvLine, val);
+                    if (!entryIsLast) appendComma(kvLine);
+                    children.appendChild(kvLine);
+                }
+            }
+
+            parent.appendChild(children);
+
+            // Closing brace
+            var closeLine = createLine();
+            appendText(closeLine, '}', 'tree-brace');
+            if (!isLast) appendComma(closeLine);
+            parent.appendChild(closeLine);
+
+            // Toggle behavior
+            toggle.addEventListener('click', function() {
+                var isCollapsed = children.classList.contains('collapsed');
+                if (isCollapsed) {
+                    children.classList.remove('collapsed');
+                    toggle.textContent = '\u25BC';
+                    summary.style.display = 'none';
+                    closeLine.style.display = '';
+                } else {
+                    children.classList.add('collapsed');
+                    toggle.textContent = '\u25B6';
+                    summary.style.display = '';
+                    closeLine.style.display = 'none';
+                }
+            });
+        }
+
+        function buildArrayNode(parent, arr, isLast) {
+            var count = arr.length;
+
+            if (count === 0) {
+                var line = createLine();
+                appendText(line, '[]', 'tree-brace');
+                if (!isLast) appendComma(line);
+                parent.appendChild(line);
+                return;
+            }
+
+            // Opening line with toggle
+            var openLine = createLine();
+            var toggle = document.createElement('span');
+            toggle.className = 'tree-toggle';
+            toggle.textContent = '\u25BC';
+            openLine.appendChild(toggle);
+            appendText(openLine, ' [', 'tree-brace');
+
+            // Summary (hidden when expanded)
+            var summary = document.createElement('span');
+            summary.className = 'tree-summary';
+            summary.textContent = ' [...] (' + count + ' item' + (count !== 1 ? 's' : '') + ')';
+            summary.style.display = 'none';
+            openLine.appendChild(summary);
+
+            parent.appendChild(openLine);
+
+            // Children container
+            var children = document.createElement('div');
+            children.className = 'tree-children';
+
+            for (var i = 0; i < arr.length; i++) {
+                var val = arr[i];
+                var entryIsLast = (i === arr.length - 1);
+                buildNode(children, val, !entryIsLast, entryIsLast);
+            }
+
+            parent.appendChild(children);
+
+            // Closing bracket
+            var closeLine = createLine();
+            appendText(closeLine, ']', 'tree-brace');
+            if (!isLast) appendComma(closeLine);
+            parent.appendChild(closeLine);
+
+            // Toggle behavior
+            toggle.addEventListener('click', function() {
+                var isCollapsed = children.classList.contains('collapsed');
+                if (isCollapsed) {
+                    children.classList.remove('collapsed');
+                    toggle.textContent = '\u25BC';
+                    summary.style.display = 'none';
+                    closeLine.style.display = '';
+                } else {
+                    children.classList.add('collapsed');
+                    toggle.textContent = '\u25B6';
+                    summary.style.display = '';
+                    closeLine.style.display = 'none';
+                }
+            });
+        }
+
+        function buildCompoundEntry(parent, key, val, isLast) {
+            // For object/array values inside an object, render:
+            // "key": { / [  (with toggle)
+            //   children
+            // } / ]
+
+            var isArray = Array.isArray(val);
+            var openBrace = isArray ? '[' : '{';
+            var closeBrace = isArray ? ']' : '}';
+            var items = isArray ? val : Object.keys(val);
+            var count = items.length;
+
+            if (count === 0) {
+                var emptyLine = createLine();
+                appendText(emptyLine, '"' + escapeString(key) + '"', 'tree-key');
+                appendText(emptyLine, ': ', 'tree-colon');
+                appendText(emptyLine, openBrace + closeBrace, 'tree-brace');
+                if (!isLast) appendComma(emptyLine);
+                parent.appendChild(emptyLine);
+                return;
+            }
+
+            // Opening line
+            var openLine = createLine();
+            var toggle = document.createElement('span');
+            toggle.className = 'tree-toggle';
+            toggle.textContent = '\u25BC';
+            openLine.appendChild(toggle);
+
+            var keySpan = document.createElement('span');
+            keySpan.className = 'tree-key';
+            keySpan.textContent = ' "' + escapeString(key) + '"';
+            openLine.appendChild(keySpan);
+
+            appendText(openLine, ': ', 'tree-colon');
+            appendText(openLine, openBrace, 'tree-brace');
+
+            // Summary
+            var summaryText = isArray
+                ? ' [...] (' + count + ' item' + (count !== 1 ? 's' : '') + ')'
+                : ' {...} (' + count + ' key' + (count !== 1 ? 's' : '') + ')';
+            var summary = document.createElement('span');
+            summary.className = 'tree-summary';
+            summary.textContent = summaryText;
+            summary.style.display = 'none';
+            openLine.appendChild(summary);
+
+            parent.appendChild(openLine);
+
+            // Children
+            var children = document.createElement('div');
+            children.className = 'tree-children';
+
+            if (isArray) {
+                for (var i = 0; i < val.length; i++) {
+                    var entryIsLast = (i === val.length - 1);
+                    buildNode(children, val[i], !entryIsLast, entryIsLast);
+                }
+            } else {
+                var keys = Object.keys(val);
+                for (var j = 0; j < keys.length; j++) {
+                    var k = keys[j];
+                    var v = val[k];
+                    var kvIsLast = (j === keys.length - 1);
+
+                    if (v !== null && typeof v === 'object') {
+                        buildCompoundEntry(children, k, v, kvIsLast);
+                    } else {
+                        var kvLine = createLine();
+                        appendText(kvLine, '"' + escapeString(k) + '"', 'tree-key');
+                        appendText(kvLine, ': ', 'tree-colon');
+                        appendPrimitive(kvLine, v);
+                        if (!kvIsLast) appendComma(kvLine);
+                        children.appendChild(kvLine);
+                    }
+                }
+            }
+
+            parent.appendChild(children);
+
+            // Closing line
+            var closeLine = createLine();
+            appendText(closeLine, closeBrace, 'tree-brace');
+            if (!isLast) appendComma(closeLine);
+            parent.appendChild(closeLine);
+
+            // Toggle
+            toggle.addEventListener('click', function() {
+                var isCollapsed = children.classList.contains('collapsed');
+                if (isCollapsed) {
+                    children.classList.remove('collapsed');
+                    toggle.textContent = '\u25BC';
+                    summary.style.display = 'none';
+                    closeLine.style.display = '';
+                } else {
+                    children.classList.add('collapsed');
+                    toggle.textContent = '\u25B6';
+                    summary.style.display = '';
+                    closeLine.style.display = 'none';
+                }
+            });
+        }
+
+        // --- Helper functions ---
+
+        function createLine() {
+            var div = document.createElement('div');
+            div.className = 'tree-line';
+            return div;
+        }
+
+        function appendText(parent, text, className) {
+            var span = document.createElement('span');
+            span.className = className;
+            span.textContent = text;
+            parent.appendChild(span);
+            return span;
+        }
+
+        function appendComma(parent) {
+            appendText(parent, ',', 'tree-comma');
+        }
+
+        function appendPrimitive(parent, val) {
+            if (val === null) {
+                appendText(parent, 'null', 'tree-null');
+            } else if (typeof val === 'boolean') {
+                appendText(parent, String(val), 'tree-boolean');
+            } else if (typeof val === 'number') {
+                appendText(parent, String(val), 'tree-number');
+            } else if (typeof val === 'string') {
+                appendText(parent, '"' + escapeString(val) + '"', 'tree-string');
+            }
+        }
+
+        function escapeString(str) {
+            return str
+                .replace(/\\/g, '\\\\')
+                .replace(/"/g, '\\"')
+                .replace(/\n/g, '\\n')
+                .replace(/\r/g, '\\r')
+                .replace(/\t/g, '\\t');
+        }
+
+        // --- Search ---
+
+        function clearSearch() {
+            searchMatches = [];
+            currentMatchIndex = -1;
+            searchInfo.textContent = '';
+        }
+
+        function applySearch() {
+            var query = searchInput.value.trim().toLowerCase();
+
+            // Clear previous highlights
+            var oldHighlights = treeView.querySelectorAll('.search-match, .search-match-active');
+            for (var i = 0; i < oldHighlights.length; i++) {
+                var hl = oldHighlights[i];
+                var parent = hl.parentNode;
+                parent.replaceChild(document.createTextNode(hl.textContent), hl);
+                parent.normalize();
+            }
+
+            searchMatches = [];
+            currentMatchIndex = -1;
+
+            if (!query || !isValid) {
+                searchInfo.textContent = '';
+                return;
+            }
+
+            // Find all text nodes in tree-key, tree-string, tree-number, tree-boolean, tree-null spans
+            var searchableClasses = ['tree-key', 'tree-string', 'tree-number', 'tree-boolean', 'tree-null'];
+            var spans = [];
+            for (var c = 0; c < searchableClasses.length; c++) {
+                var found = treeView.querySelectorAll('.' + searchableClasses[c]);
+                for (var f = 0; f < found.length; f++) {
+                    spans.push(found[f]);
+                }
+            }
+
+            for (var s = 0; s < spans.length; s++) {
+                var span = spans[s];
+                var text = span.textContent;
+                var lowerText = text.toLowerCase();
+                var idx = lowerText.indexOf(query);
+
+                if (idx === -1) continue;
+
+                // Split and wrap matches
+                var fragment = document.createDocumentFragment();
+                var lastIdx = 0;
+
+                while (idx !== -1) {
+                    // Text before match
+                    if (idx > lastIdx) {
+                        fragment.appendChild(document.createTextNode(text.substring(lastIdx, idx)));
+                    }
+
+                    // The match
+                    var matchSpan = document.createElement('span');
+                    matchSpan.className = 'search-match';
+                    matchSpan.textContent = text.substring(idx, idx + query.length);
+                    fragment.appendChild(matchSpan);
+                    searchMatches.push(matchSpan);
+
+                    lastIdx = idx + query.length;
+                    idx = lowerText.indexOf(query, lastIdx);
+                }
+
+                // Remaining text
+                if (lastIdx < text.length) {
+                    fragment.appendChild(document.createTextNode(text.substring(lastIdx)));
+                }
+
+                // Replace span contents
+                var parentSpan = span;
+                while (parentSpan.firstChild) {
+                    parentSpan.removeChild(parentSpan.firstChild);
+                }
+                parentSpan.appendChild(fragment);
+            }
+
+            var total = searchMatches.length;
+            if (total > 0) {
+                currentMatchIndex = 0;
+                highlightCurrentMatch();
+                searchInfo.textContent = '1 of ' + total + ' match' + (total !== 1 ? 'es' : '');
+            } else {
+                searchInfo.textContent = '0 matches';
+            }
+        }
+
+        function highlightCurrentMatch() {
+            // Remove active highlight from all
+            for (var i = 0; i < searchMatches.length; i++) {
+                searchMatches[i].className = 'search-match';
+            }
+
+            if (currentMatchIndex >= 0 && currentMatchIndex < searchMatches.length) {
+                var match = searchMatches[currentMatchIndex];
+                match.className = 'search-match-active';
+
+                // Expand parent collapsed nodes
+                expandParents(match);
+
+                // Scroll into view
+                match.scrollIntoView({ block: 'center', behavior: 'smooth' });
+            }
+        }
+
+        function expandParents(element) {
+            var node = element.parentElement;
+            while (node && node !== treeView) {
+                if (node.classList.contains('tree-children') && node.classList.contains('collapsed')) {
+                    node.classList.remove('collapsed');
+                    // Find the toggle and summary siblings
+                    var prev = node.previousElementSibling;
+                    if (prev) {
+                        var toggle = prev.querySelector('.tree-toggle');
+                        var summary = prev.querySelector('.tree-summary');
+                        if (toggle) toggle.textContent = '\u25BC';
+                        if (summary) summary.style.display = 'none';
+                    }
+                    // Show closing line
+                    var next = node.nextElementSibling;
+                    if (next) {
+                        next.style.display = '';
+                    }
+                }
+                node = node.parentElement;
+            }
+        }
+
+        function navigateMatch(direction) {
+            if (searchMatches.length === 0) return;
+
+            currentMatchIndex += direction;
+            if (currentMatchIndex >= searchMatches.length) {
+                currentMatchIndex = 0;
+            } else if (currentMatchIndex < 0) {
+                currentMatchIndex = searchMatches.length - 1;
+            }
+
+            highlightCurrentMatch();
+            searchInfo.textContent = (currentMatchIndex + 1) + ' of ' + searchMatches.length + ' match' + (searchMatches.length !== 1 ? 'es' : '');
+        }
+
+        // --- Clipboard ---
+
+        function copyToClipboard(text, button) {
+            navigator.clipboard.writeText(text).then(function() {
+                var originalText = button.textContent;
+                button.textContent = 'Copied!';
+                button.classList.add('copied');
+                setTimeout(function() {
+                    button.textContent = originalText;
+                    button.classList.remove('copied');
+                }, 1500);
+            }).catch(function() {
+                // Fallback
+                var textarea = document.createElement('textarea');
+                textarea.value = text;
+                textarea.style.position = 'fixed';
+                textarea.style.opacity = '0';
+                document.body.appendChild(textarea);
+                textarea.select();
+                document.execCommand('copy');
+                document.body.removeChild(textarea);
+                var originalText = button.textContent;
+                button.textContent = 'Copied!';
+                button.classList.add('copied');
+                setTimeout(function() {
+                    button.textContent = originalText;
+                    button.classList.remove('copied');
+                }, 1500);
+            });
+        }
+
+        // --- Error display ---
+
+        function showError(msg) {
+            errorMsg.textContent = msg;
+            errorMsg.classList.add('visible');
+        }
+
+        function hideError() {
+            errorMsg.classList.remove('visible');
+        }
+
+    })();
+    </script>
+</body>
+</html>

--- a/tools/latex-preview.html
+++ b/tools/latex-preview.html
@@ -1,0 +1,996 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <script src="analytics.js"></script>
+    <title>LaTeX Math Preview</title>
+
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16/dist/katex.min.css">
+    <script src="https://cdn.jsdelivr.net/npm/katex@0.16/dist/katex.min.js"></script>
+
+    <style>
+        :root {
+            --bg-body: #1d1e20;
+            --bg-card: #2e2e33;
+            --bg-inset: #37383e;
+            --bg-hover: #414244;
+            --border: #333333;
+            --text-primary: #dadada;
+            --text-content: #c4c4c5;
+            --text-muted: #9b9c9d;
+            --text-dim: #707073;
+            --accent: #75A8D9;
+            --accent-hover: #8fbce5;
+            --accent-dim: rgba(117, 168, 217, 0.15);
+            --green: #72994E;
+            --green-dim: rgba(114, 153, 78, 0.15);
+            --orange: #EE6331;
+            --orange-dim: rgba(238, 99, 49, 0.12);
+            --code-bg: #37383e;
+        }
+
+        *, *::before, *::after {
+            box-sizing: border-box;
+            margin: 0;
+            padding: 0;
+        }
+
+        body {
+            background: var(--bg-body);
+            color: var(--text-content);
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell, "Fira Sans", "Droid Sans", "Helvetica Neue", Arial, sans-serif;
+            padding: 24px 20px;
+            min-height: 100vh;
+        }
+
+        .container {
+            max-width: 800px;
+            margin: 0 auto;
+        }
+
+        header {
+            text-align: center;
+            margin-bottom: 24px;
+        }
+
+        .back-link {
+            color: var(--accent);
+            text-decoration: none;
+            font-size: 14px;
+            display: inline-block;
+            margin-bottom: 10px;
+            transition: color 0.15s;
+        }
+
+        .back-link:hover {
+            color: var(--accent-hover);
+            text-decoration: underline;
+        }
+
+        header h1 {
+            color: var(--text-primary);
+            font-size: 22px;
+            font-weight: 700;
+        }
+
+        .error-msg {
+            display: none;
+            background: var(--orange-dim);
+            border: 1px solid var(--orange);
+            color: var(--orange);
+            border-radius: 8px;
+            padding: 10px 14px;
+            font-size: 13px;
+            font-weight: 500;
+            margin-bottom: 16px;
+            text-align: center;
+        }
+
+        .error-msg.visible {
+            display: block;
+        }
+
+        .panel {
+            background: var(--bg-card);
+            border: 1px solid var(--border);
+            border-radius: 10px;
+            padding: 16px;
+            margin-bottom: 12px;
+        }
+
+        .panel-label {
+            font-size: 12px;
+            font-weight: 600;
+            letter-spacing: 0.04em;
+            text-transform: uppercase;
+            color: var(--text-muted);
+            margin-bottom: 12px;
+        }
+
+        /* Toolbar */
+        .toolbar {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 8px;
+            margin-bottom: 12px;
+            align-items: center;
+        }
+
+        .toolbar-group {
+            display: flex;
+            gap: 4px;
+            align-items: center;
+        }
+
+        .toolbar-sep {
+            width: 1px;
+            height: 20px;
+            background: var(--border);
+            margin: 0 4px;
+        }
+
+        .ctrl-btn {
+            background: var(--bg-inset);
+            border: 1px solid var(--border);
+            border-radius: 6px;
+            padding: 5px 10px;
+            cursor: pointer;
+            color: var(--text-content);
+            font-family: inherit;
+            font-size: 12px;
+            font-weight: 500;
+            transition: all 0.15s;
+            white-space: nowrap;
+        }
+
+        .ctrl-btn:hover {
+            border-color: var(--accent);
+            background: var(--accent-dim);
+            color: var(--text-primary);
+        }
+
+        .ctrl-btn.active {
+            border-color: var(--accent);
+            background: var(--accent-dim);
+            color: var(--accent);
+            font-weight: 600;
+        }
+
+        .ctrl-btn.copied {
+            border-color: var(--green);
+            color: var(--green);
+            background: var(--green-dim);
+        }
+
+        .font-size-label {
+            font-size: 12px;
+            color: var(--text-muted);
+            margin: 0 2px;
+            min-width: 32px;
+            text-align: center;
+        }
+
+        /* Textarea */
+        #latex-input {
+            width: 100%;
+            min-height: 180px;
+            resize: vertical;
+            background: var(--bg-inset);
+            border: 1px solid var(--border);
+            border-radius: 6px;
+            padding: 12px;
+            font-family: "SF Mono", "Fira Code", "Fira Mono", Menlo, Consolas, monospace;
+            font-size: 13px;
+            color: var(--text-content);
+            line-height: 1.5;
+            tab-size: 2;
+            outline: none;
+            transition: border-color 0.15s, background 0.15s;
+        }
+
+        #latex-input:focus {
+            border-color: var(--accent);
+        }
+
+        #latex-input.drag-over {
+            border-color: var(--accent);
+            background: var(--accent-dim);
+        }
+
+        .status-bar {
+            font-size: 12px;
+            color: var(--text-muted);
+            margin-top: 6px;
+        }
+
+        /* Preview */
+        .preview-area {
+            min-height: 300px;
+            padding: 20px 16px;
+            background: var(--bg-inset);
+            border: 1px solid var(--border);
+            border-radius: 6px;
+        }
+
+        .eq-block {
+            margin-bottom: 16px;
+        }
+
+        .eq-block:last-child {
+            margin-bottom: 0;
+        }
+
+        .eq-display {
+            text-align: center;
+            overflow-x: auto;
+            padding: 4px 0;
+        }
+
+        .eq-inline {
+            text-align: left;
+            overflow-x: auto;
+            padding: 4px 0;
+        }
+
+        .eq-spacer {
+            height: 12px;
+        }
+
+        .eq-comment {
+            color: var(--text-dim);
+            font-style: italic;
+            font-size: 13px;
+            font-family: "SF Mono", "Fira Code", "Fira Mono", Menlo, Consolas, monospace;
+            padding: 2px 0;
+        }
+
+        .eq-error-source {
+            color: var(--text-muted);
+            font-family: "SF Mono", "Fira Code", "Fira Mono", Menlo, Consolas, monospace;
+            font-size: 13px;
+            padding: 4px 8px;
+            background: var(--bg-card);
+            border-radius: 4px;
+            overflow-x: auto;
+            white-space: pre-wrap;
+            word-break: break-all;
+        }
+
+        .eq-error-msg {
+            color: var(--orange);
+            font-size: 12px;
+            margin-top: 4px;
+            padding-left: 8px;
+        }
+
+        .preview-empty {
+            color: var(--text-dim);
+            font-size: 14px;
+            text-align: center;
+            padding: 40px 0;
+        }
+
+        /* Details / collapsible sections */
+        details {
+            margin-bottom: 12px;
+        }
+
+        details summary {
+            cursor: pointer;
+            font-size: 13px;
+            font-weight: 600;
+            color: var(--text-muted);
+            padding: 8px 12px;
+            background: var(--bg-card);
+            border: 1px solid var(--border);
+            border-radius: 8px;
+            list-style: none;
+            user-select: none;
+            transition: all 0.15s;
+        }
+
+        details summary::-webkit-details-marker {
+            display: none;
+        }
+
+        details summary::before {
+            content: "▸ ";
+            color: var(--text-dim);
+            transition: transform 0.15s;
+            display: inline-block;
+        }
+
+        details[open] summary::before {
+            content: "▾ ";
+        }
+
+        details summary:hover {
+            border-color: var(--accent);
+            color: var(--text-primary);
+        }
+
+        details[open] summary {
+            border-radius: 8px 8px 0 0;
+            border-bottom-color: transparent;
+        }
+
+        .details-body {
+            background: var(--bg-card);
+            border: 1px solid var(--border);
+            border-top: none;
+            border-radius: 0 0 8px 8px;
+            padding: 12px;
+        }
+
+        /* Symbol grid */
+        .symbol-category {
+            margin-bottom: 10px;
+        }
+
+        .symbol-category:last-child {
+            margin-bottom: 0;
+        }
+
+        .symbol-cat-label {
+            font-size: 11px;
+            font-weight: 700;
+            color: var(--text-muted);
+            text-transform: uppercase;
+            letter-spacing: 0.04em;
+            margin-bottom: 6px;
+        }
+
+        .symbol-grid {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 4px;
+        }
+
+        .symbol-btn {
+            background: var(--bg-inset);
+            border: 1px solid var(--border);
+            border-radius: 4px;
+            padding: 3px 8px;
+            font-family: "SF Mono", "Fira Code", "Fira Mono", Menlo, Consolas, monospace;
+            font-size: 12px;
+            color: var(--text-content);
+            cursor: pointer;
+            transition: all 0.15s;
+            white-space: nowrap;
+        }
+
+        .symbol-btn:hover {
+            border-color: var(--accent);
+            background: var(--accent-dim);
+            color: var(--text-primary);
+        }
+
+        /* Snippets */
+        .snippet-controls {
+            display: flex;
+            gap: 8px;
+            margin-bottom: 10px;
+            align-items: center;
+        }
+
+        .snippet-name-input {
+            flex: 1;
+            background: var(--bg-inset);
+            border: 1px solid var(--border);
+            border-radius: 6px;
+            padding: 5px 10px;
+            font-family: inherit;
+            font-size: 12px;
+            color: var(--text-content);
+            outline: none;
+            transition: border-color 0.15s;
+        }
+
+        .snippet-name-input:focus {
+            border-color: var(--accent);
+        }
+
+        .snippet-name-input::placeholder {
+            color: var(--text-dim);
+        }
+
+        .snippet-list {
+            display: flex;
+            flex-direction: column;
+            gap: 6px;
+        }
+
+        .snippet-item {
+            display: flex;
+            align-items: center;
+            gap: 8px;
+            padding: 6px 10px;
+            background: var(--bg-inset);
+            border: 1px solid var(--border);
+            border-radius: 6px;
+        }
+
+        .snippet-item-name {
+            flex: 1;
+            font-size: 13px;
+            color: var(--text-content);
+            overflow: hidden;
+            text-overflow: ellipsis;
+            white-space: nowrap;
+        }
+
+        .snippet-item-btn {
+            background: none;
+            border: 1px solid var(--border);
+            border-radius: 4px;
+            padding: 2px 8px;
+            font-size: 11px;
+            color: var(--text-muted);
+            cursor: pointer;
+            font-family: inherit;
+            transition: all 0.15s;
+        }
+
+        .snippet-item-btn:hover {
+            border-color: var(--accent);
+            color: var(--text-primary);
+        }
+
+        .snippet-item-btn.delete:hover {
+            border-color: var(--orange);
+            color: var(--orange);
+        }
+
+        .snippet-empty {
+            font-size: 12px;
+            color: var(--text-dim);
+            text-align: center;
+            padding: 8px;
+        }
+
+        /* KaTeX overrides for dark theme */
+        .katex { color: var(--text-primary); }
+        .katex .mord, .katex .mop, .katex .mrel,
+        .katex .mopen, .katex .mclose, .katex .mpunct,
+        .katex .mbin, .katex .minner { color: inherit; }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <header>
+            <a href="./" class="back-link">&larr; Back to Tools</a>
+            <h1>LaTeX Math Preview</h1>
+        </header>
+
+        <div id="error-msg" class="error-msg"></div>
+
+        <!-- Toolbar -->
+        <div class="toolbar">
+            <div class="toolbar-group">
+                <button class="ctrl-btn active" id="btn-display" onclick="setMode('display')">Display</button>
+                <button class="ctrl-btn" id="btn-inline" onclick="setMode('inline')">Inline</button>
+                <button class="ctrl-btn" id="btn-auto" onclick="setMode('auto')">Auto</button>
+            </div>
+            <div class="toolbar-sep"></div>
+            <div class="toolbar-group">
+                <button class="ctrl-btn" id="btn-copy" onclick="copyLatex()">Copy LaTeX</button>
+                <button class="ctrl-btn" onclick="clearAll()">Clear</button>
+                <button class="ctrl-btn" onclick="loadSample()">Load Sample</button>
+            </div>
+            <div class="toolbar-sep"></div>
+            <div class="toolbar-group">
+                <button class="ctrl-btn" onclick="changeFontSize(-2)">A&minus;</button>
+                <span class="font-size-label" id="font-size-label">18px</span>
+                <button class="ctrl-btn" onclick="changeFontSize(2)">A+</button>
+            </div>
+        </div>
+
+        <!-- Common Symbols -->
+        <details>
+            <summary>Common Symbols</summary>
+            <div class="details-body" id="symbols-body"></div>
+        </details>
+
+        <!-- Saved Snippets -->
+        <details>
+            <summary>Saved Snippets</summary>
+            <div class="details-body">
+                <div class="snippet-controls">
+                    <input type="text" class="snippet-name-input" id="snippet-name" placeholder="Snippet name (optional)" maxlength="60">
+                    <button class="ctrl-btn" onclick="saveSnippet()">Save Current</button>
+                </div>
+                <div class="snippet-list" id="snippet-list"></div>
+            </div>
+        </details>
+
+        <!-- Input panel -->
+        <div class="panel">
+            <div class="panel-label">LaTeX Input</div>
+            <textarea id="latex-input" spellcheck="false" placeholder="Type LaTeX equations here, one per line...&#10;Lines starting with % are comments.&#10;Empty lines create spacing."></textarea>
+            <div class="status-bar" id="status-bar">0 equations</div>
+        </div>
+
+        <!-- Preview panel -->
+        <div class="panel">
+            <div class="panel-label">Preview</div>
+            <div class="preview-area" id="preview-area">
+                <div class="preview-empty">Type LaTeX above to see a live preview</div>
+            </div>
+        </div>
+    </div>
+
+<script>
+(function() {
+    "use strict";
+
+    // --- State ---
+    let currentMode = 'display'; // 'display' | 'inline' | 'auto'
+    let fontSize = 18;
+    let debounceTimer = null;
+
+    const MACROS = {
+        "\\argmax": "\\operatorname*{arg\\,max}",
+        "\\argmin": "\\operatorname*{arg\\,min}",
+        "\\KL": "\\operatorname{KL}",
+        "\\SFT": "\\operatorname{SFT}",
+        "\\ref": "\\operatorname{ref}"
+    };
+
+    const SAMPLE = `% === PPO Clipped Surrogate Objective ===
+L^{CLIP}(\\theta) = \\hat{\\mathbb{E}}_t \\left[ \\min\\left( r_t(\\theta) \\hat{A}_t, \\; \\text{clip}\\left( r_t(\\theta), 1-\\epsilon, 1+\\epsilon \\right) \\hat{A}_t \\right) \\right]
+
+% === DPO Loss ===
+\\mathcal{L}_{\\text{DPO}}(\\pi_\\theta; \\pi_{\\text{ref}}) = -\\mathbb{E}_{(x, y_w, y_l) \\sim \\mathcal{D}} \\left[ \\log \\sigma \\left( \\beta \\log \\frac{\\pi_\\theta(y_w|x)}{\\pi_{\\text{ref}}(y_w|x)} - \\beta \\log \\frac{\\pi_\\theta(y_l|x)}{\\pi_{\\text{ref}}(y_l|x)} \\right) \\right]
+
+% === GRPO Group Advantage ===
+\\hat{A}_i = \\frac{r_i - \\text{mean}(\\{r_1, \\ldots, r_G\\})}{\\text{std}(\\{r_1, \\ldots, r_G\\})}
+
+% === KL Divergence ===
+D_{\\text{KL}}(P \\| Q) = \\sum_{x \\in \\mathcal{X}} P(x) \\log \\frac{P(x)}{Q(x)}
+
+% === Bradley-Terry Preference Model ===
+P(y_w \\succ y_l | x) = \\frac{\\exp(r(x, y_w))}{\\exp(r(x, y_w)) + \\exp(r(x, y_l))} = \\sigma(r(x, y_w) - r(x, y_l))`;
+
+    const SYMBOLS = [
+        {
+            label: "Greek Letters",
+            items: [
+                "\\alpha", "\\beta", "\\gamma", "\\delta", "\\epsilon", "\\theta",
+                "\\lambda", "\\mu", "\\sigma", "\\pi", "\\phi", "\\psi", "\\omega",
+                "\\Gamma", "\\Delta", "\\Theta", "\\Lambda", "\\Sigma", "\\Phi", "\\Psi", "\\Omega"
+            ]
+        },
+        {
+            label: "Operators",
+            items: [
+                "\\sum", "\\prod", "\\int", "\\partial", "\\nabla", "\\infty",
+                "\\approx", "\\neq", "\\leq", "\\geq", "\\pm", "\\times", "\\cdot", "\\div"
+            ]
+        },
+        {
+            label: "Relations & Logic",
+            items: [
+                "\\in", "\\notin", "\\subset", "\\subseteq", "\\cup", "\\cap",
+                "\\forall", "\\exists", "\\neg", "\\implies", "\\iff"
+            ]
+        },
+        {
+            label: "ML / Probability",
+            items: [
+                "\\mathbb{E}", "\\mathbb{R}", "\\mathcal{L}", "\\mathcal{D}",
+                "\\log", "\\exp", "\\max", "\\min", "\\argmax", "\\argmin",
+                "\\KL", "\\text{softmax}", "\\text{sigmoid}"
+            ]
+        },
+        {
+            label: "Arrows & Misc",
+            items: [
+                "\\rightarrow", "\\leftarrow", "\\leftrightarrow",
+                "\\Rightarrow", "\\Leftarrow", "\\mapsto",
+                "\\ldots", "\\cdots", "\\underbrace{}", "\\overbrace{}"
+            ]
+        },
+        {
+            label: "Decorations",
+            items: [
+                "\\hat{}", "\\bar{}", "\\tilde{}", "\\vec{}",
+                "\\dot{}", "\\mathbf{}", "\\mathrm{}", "\\boldsymbol{}"
+            ]
+        }
+    ];
+
+    // --- DOM refs ---
+    const textarea = document.getElementById('latex-input');
+    const previewArea = document.getElementById('preview-area');
+    const statusBar = document.getElementById('status-bar');
+    const errorMsg = document.getElementById('error-msg');
+    const fontSizeLabel = document.getElementById('font-size-label');
+
+    // --- Init ---
+    function init() {
+        loadFontSize();
+        buildSymbolGrid();
+        renderSnippetList();
+        loadSample();
+
+        textarea.addEventListener('input', scheduleRender);
+        setupDragDrop();
+    }
+
+    // --- Mode ---
+    window.setMode = function(mode) {
+        currentMode = mode;
+        document.getElementById('btn-display').classList.toggle('active', mode === 'display');
+        document.getElementById('btn-inline').classList.toggle('active', mode === 'inline');
+        document.getElementById('btn-auto').classList.toggle('active', mode === 'auto');
+        renderPreview();
+    };
+
+    // --- Font size ---
+    function loadFontSize() {
+        try {
+            const saved = localStorage.getItem('latex-preview-font-size');
+            if (saved) {
+                const v = parseInt(saved, 10);
+                if (v >= 12 && v <= 32) fontSize = v;
+            }
+        } catch(e) {}
+        updateFontSizeLabel();
+    }
+
+    function saveFontSize() {
+        try { localStorage.setItem('latex-preview-font-size', fontSize); } catch(e) {}
+    }
+
+    function updateFontSizeLabel() {
+        fontSizeLabel.textContent = fontSize + 'px';
+    }
+
+    window.changeFontSize = function(delta) {
+        const next = fontSize + delta;
+        if (next < 12 || next > 32) return;
+        fontSize = next;
+        updateFontSizeLabel();
+        saveFontSize();
+        renderPreview();
+    };
+
+    // --- Copy ---
+    window.copyLatex = function() {
+        const btn = document.getElementById('btn-copy');
+        const text = textarea.value;
+        if (!text.trim()) return;
+        navigator.clipboard.writeText(text).then(function() {
+            btn.textContent = 'Copied!';
+            btn.classList.add('copied');
+            setTimeout(function() {
+                btn.textContent = 'Copy LaTeX';
+                btn.classList.remove('copied');
+            }, 1500);
+        }).catch(function() {
+            // Fallback
+            const ta = document.createElement('textarea');
+            ta.value = text;
+            document.body.appendChild(ta);
+            ta.select();
+            document.execCommand('copy');
+            document.body.removeChild(ta);
+            btn.textContent = 'Copied!';
+            btn.classList.add('copied');
+            setTimeout(function() {
+                btn.textContent = 'Copy LaTeX';
+                btn.classList.remove('copied');
+            }, 1500);
+        });
+    };
+
+    // --- Clear ---
+    window.clearAll = function() {
+        textarea.value = '';
+        renderPreview();
+        textarea.focus();
+    };
+
+    // --- Load sample ---
+    window.loadSample = function() {
+        textarea.value = SAMPLE;
+        renderPreview();
+    };
+
+    // --- Render logic ---
+    function scheduleRender() {
+        clearTimeout(debounceTimer);
+        debounceTimer = setTimeout(renderPreview, 200);
+    }
+
+    function renderPreview() {
+        hideError();
+        const text = textarea.value;
+        const lines = text.split('\n');
+
+        if (!text.trim()) {
+            previewArea.innerHTML = '<div class="preview-empty">Type LaTeX above to see a live preview</div>';
+            statusBar.textContent = '0 equations';
+            return;
+        }
+
+        let html = '';
+        let eqCount = 0;
+
+        for (let i = 0; i < lines.length; i++) {
+            const line = lines[i];
+            const trimmed = line.trim();
+
+            // Empty line = spacer
+            if (trimmed === '') {
+                html += '<div class="eq-spacer"></div>';
+                continue;
+            }
+
+            // Comment line
+            if (trimmed.startsWith('%')) {
+                html += '<div class="eq-block"><div class="eq-comment">' + escapeHtml(trimmed) + '</div></div>';
+                continue;
+            }
+
+            // Math line
+            eqCount++;
+            const parsed = parseLine(trimmed);
+            const latex = parsed.latex;
+            const displayMode = parsed.displayMode;
+
+            try {
+                const rendered = katex.renderToString(latex, {
+                    throwOnError: true,
+                    displayMode: displayMode,
+                    macros: MACROS
+                });
+                const wrapClass = displayMode ? 'eq-display' : 'eq-inline';
+                html += '<div class="eq-block"><div class="' + wrapClass + '" style="font-size:' + fontSize + 'px;">' + rendered + '</div></div>';
+            } catch(e) {
+                const errText = e.message || String(e);
+                html += '<div class="eq-block">';
+                html += '<div class="eq-error-source">' + escapeHtml(trimmed) + '</div>';
+                html += '<div class="eq-error-msg">' + escapeHtml(errText) + '</div>';
+                html += '</div>';
+            }
+        }
+
+        previewArea.innerHTML = html;
+        statusBar.textContent = eqCount + ' equation' + (eqCount !== 1 ? 's' : '');
+    }
+
+    function parseLine(line) {
+        if (currentMode === 'display') {
+            return { latex: line, displayMode: true };
+        }
+        if (currentMode === 'inline') {
+            return { latex: line, displayMode: false };
+        }
+
+        // Auto mode: detect delimiters
+        // $$...$$ or \[...\]
+        let m;
+        m = line.match(/^\$\$([\s\S]*)\$\$$/);
+        if (m) return { latex: m[1], displayMode: true };
+
+        m = line.match(/^\\\[([\s\S]*)\\\]$/);
+        if (m) return { latex: m[1], displayMode: true };
+
+        // $...$ or \(...\)
+        m = line.match(/^\$((?:[^$]|\\\$)*)\$$/);
+        if (m) return { latex: m[1], displayMode: false };
+
+        m = line.match(/^\\\(([\s\S]*)\\\)$/);
+        if (m) return { latex: m[1], displayMode: false };
+
+        // No delimiters: default to display
+        return { latex: line, displayMode: true };
+    }
+
+    function escapeHtml(str) {
+        return str.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
+    }
+
+    // --- Error display ---
+    function showError(msg) {
+        errorMsg.textContent = msg;
+        errorMsg.classList.add('visible');
+    }
+
+    function hideError() {
+        errorMsg.textContent = '';
+        errorMsg.classList.remove('visible');
+    }
+
+    // --- Drag and drop ---
+    function setupDragDrop() {
+        textarea.addEventListener('dragover', function(e) {
+            e.preventDefault();
+            e.stopPropagation();
+            textarea.classList.add('drag-over');
+        });
+
+        textarea.addEventListener('dragleave', function(e) {
+            e.preventDefault();
+            e.stopPropagation();
+            textarea.classList.remove('drag-over');
+        });
+
+        textarea.addEventListener('drop', function(e) {
+            e.preventDefault();
+            e.stopPropagation();
+            textarea.classList.remove('drag-over');
+
+            const files = e.dataTransfer.files;
+            if (!files || files.length === 0) return;
+
+            const file = files[0];
+            const name = file.name.toLowerCase();
+            const validExts = ['.tex', '.txt', '.latex'];
+            const ext = name.substring(name.lastIndexOf('.'));
+
+            if (!validExts.includes(ext)) {
+                showError('Invalid file type. Please drop a .tex, .txt, or .latex file.');
+                return;
+            }
+
+            if (file.size > 5 * 1024 * 1024) {
+                showError('File too large. Maximum size is 5 MB.');
+                return;
+            }
+
+            const reader = new FileReader();
+            reader.onload = function(ev) {
+                textarea.value = ev.target.result;
+                renderPreview();
+            };
+            reader.onerror = function() {
+                showError('Failed to read file.');
+            };
+            reader.readAsText(file);
+        });
+    }
+
+    // --- Symbol grid ---
+    function buildSymbolGrid() {
+        const container = document.getElementById('symbols-body');
+        let html = '';
+
+        for (let c = 0; c < SYMBOLS.length; c++) {
+            const cat = SYMBOLS[c];
+            html += '<div class="symbol-category">';
+            html += '<div class="symbol-cat-label">' + escapeHtml(cat.label) + '</div>';
+            html += '<div class="symbol-grid">';
+            for (let s = 0; s < cat.items.length; s++) {
+                const sym = cat.items[s];
+                html += '<button class="symbol-btn" data-symbol="' + escapeHtml(sym) + '">' + escapeHtml(sym) + '</button>';
+            }
+            html += '</div></div>';
+        }
+
+        container.innerHTML = html;
+
+        container.addEventListener('click', function(e) {
+            const btn = e.target.closest('.symbol-btn');
+            if (!btn) return;
+            const sym = btn.getAttribute('data-symbol');
+            insertSymbol(sym);
+        });
+    }
+
+    function insertSymbol(sym) {
+        textarea.focus();
+        const start = textarea.selectionStart;
+        const end = textarea.selectionEnd;
+        const before = textarea.value.substring(0, start);
+        const after = textarea.value.substring(end);
+
+        textarea.value = before + sym + after;
+
+        // If symbol ends with {}, place cursor inside braces
+        if (sym.endsWith('{}')) {
+            const cursorPos = start + sym.length - 1;
+            textarea.setSelectionRange(cursorPos, cursorPos);
+        } else {
+            const cursorPos = start + sym.length;
+            textarea.setSelectionRange(cursorPos, cursorPos);
+        }
+
+        scheduleRender();
+    }
+
+    // --- Snippets ---
+    function getSnippets() {
+        try {
+            const raw = localStorage.getItem('latex-preview-snippets');
+            if (raw) {
+                const arr = JSON.parse(raw);
+                if (Array.isArray(arr)) return arr;
+            }
+        } catch(e) {}
+        return [];
+    }
+
+    function saveSnippets(arr) {
+        try {
+            localStorage.setItem('latex-preview-snippets', JSON.stringify(arr));
+        } catch(e) {}
+    }
+
+    window.saveSnippet = function() {
+        const content = textarea.value.trim();
+        if (!content) {
+            showError('Nothing to save. Type some LaTeX first.');
+            return;
+        }
+
+        const nameInput = document.getElementById('snippet-name');
+        let name = nameInput.value.trim();
+        if (!name) {
+            // Use first 40 chars of content
+            name = content.substring(0, 40).replace(/\n/g, ' ');
+            if (content.length > 40) name += '...';
+        }
+
+        const snippets = getSnippets();
+        if (snippets.length >= 20) {
+            showError('Maximum 20 snippets. Please delete some before saving.');
+            return;
+        }
+
+        snippets.push({ name: name, content: content });
+        saveSnippets(snippets);
+        nameInput.value = '';
+        renderSnippetList();
+    };
+
+    function renderSnippetList() {
+        const container = document.getElementById('snippet-list');
+        const snippets = getSnippets();
+
+        if (snippets.length === 0) {
+            container.innerHTML = '<div class="snippet-empty">No saved snippets yet</div>';
+            return;
+        }
+
+        let html = '';
+        for (let i = 0; i < snippets.length; i++) {
+            html += '<div class="snippet-item">';
+            html += '<span class="snippet-item-name">' + escapeHtml(snippets[i].name) + '</span>';
+            html += '<button class="snippet-item-btn" onclick="loadSnippet(' + i + ')">Load</button>';
+            html += '<button class="snippet-item-btn delete" onclick="deleteSnippet(' + i + ')">&times;</button>';
+            html += '</div>';
+        }
+        container.innerHTML = html;
+    }
+
+    window.loadSnippet = function(index) {
+        const snippets = getSnippets();
+        if (index >= 0 && index < snippets.length) {
+            textarea.value = snippets[index].content;
+            renderPreview();
+            textarea.focus();
+        }
+    };
+
+    window.deleteSnippet = function(index) {
+        const snippets = getSnippets();
+        if (index >= 0 && index < snippets.length) {
+            snippets.splice(index, 1);
+            saveSnippets(snippets);
+            renderSnippetList();
+        }
+    };
+
+    // --- Start ---
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', init);
+    } else {
+        init();
+    }
+})();
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- **JSON Formatter & Viewer** — split-pane with collapsible tree view, syntax highlighting, search, validation with line/col errors, format/minify/copy
- **Diff Viewer** — side-by-side and unified modes with line-level + word-level highlighting, swap, copy unified diff (uses jsdiff CDN)
- **LaTeX Math Preview** — stacked layout with live KaTeX rendering, Display/Inline/Auto modes, per-equation error display, symbol palette, saved snippets, custom macros

## Test plan
- [x] All 3 tools tested locally via `quarto preview`
- [x] New entries appear on Tools listing page under "Viewer Tools"

🤖 Generated with [Claude Code](https://claude.com/claude-code)