### PR TITLE
move YAML-JSON converter to new Data Tools category

### DIFF
--- a/.claude/rules/tools-catalog.md
+++ b/.claude/rules/tools-catalog.md
@@ -27,6 +27,11 @@ Inventory of all browser-based tools. Check here before building a new tool to r
 | JSON Formatter & Viewer | `json-formatter.html` | Format, validate, collapsible tree, search, copy | None |
 | Diff Viewer | `diff-viewer.html` | Side-by-side and unified diff with word-level highlighting | jsdiff |
 | LaTeX Math Preview | `latex-preview.html` | Live KaTeX rendering, symbol palette, saved snippets | KaTeX |
+
+## Data Tools
+
+| Tool | File | Description | Dependencies |
+|------|------|-------------|--------------|
 | YAML ↔ JSON Converter | `yaml-json-converter.html` | Bidirectional YAML/JSON conversion with validation | js-yaml |
 
 ## CDN Libraries in Use

--- a/tools/index.qmd
+++ b/tools/index.qmd
@@ -105,6 +105,12 @@ Type LaTeX and see it rendered instantly with KaTeX. Per-equation error feedback
 :::
 :::
 
+:::
+
+## Data Tools
+
+::: {.tools-list}
+
 ::: {.tool-item}
 [YAML ↔ JSON Converter](yaml-json-converter.html){.tool-link} [bidirectional conversion with validation]{.tool-tagline}
 


### PR DESCRIPTION
## Summary
- Created new "Data Tools" category in tools listing and catalog
- Moved YAML ↔ JSON Converter from Viewer Tools to Data Tools

🤖 Generated with [Claude Code](https://claude.com/claude-code)