### PR TITLE
Add search filter to tools listing page

### DIFF
--- a/tools/index.qmd
+++ b/tools/index.qmd
@@ -5,7 +5,15 @@ sidebar: false
 toc: true
 ---
 
-A collection of free, browser-based utilities. Everything runs locally in your browser.
+```{=html}
+<div class="listing-actions-group">
+  <div class="input-group input-group-sm quarto-listing-filter">
+    <span class="input-group-text"><i class="bi bi-search"></i></span>
+    <input id="tools-filter" type="text" class="search form-control" placeholder="Filter">
+  </div>
+</div>
+<div id="tools-no-results" style="display: none; padding: 1.5rem 0; color: #888; font-style: italic;">No tools match your search.</div>
+```
 
 ## Image Tools
 
@@ -139,6 +147,45 @@ document.addEventListener('DOMContentLoaded', () => {
       if (e.target.closest('a.tool-link')) return;
       desc.classList.toggle('open');
     });
+  });
+
+  // Search/filter functionality
+  const filterInput = document.getElementById('tools-filter');
+  const noResults = document.getElementById('tools-no-results');
+  if (!filterInput) return;
+
+  filterInput.addEventListener('input', () => {
+    const query = filterInput.value.toLowerCase().trim();
+    let totalVisible = 0;
+
+    document.querySelectorAll('.tools-list').forEach(list => {
+      const heading = list.previousElementSibling;
+      let visibleInSection = 0;
+
+      list.querySelectorAll('.tool-item').forEach(item => {
+        const link = item.querySelector('.tool-link');
+        const tagline = item.querySelector('.tool-tagline');
+        const desc = item.querySelector('.tool-desc');
+        const text = [
+          link ? link.textContent : '',
+          tagline ? tagline.textContent : '',
+          desc ? desc.textContent : ''
+        ].join(' ').toLowerCase();
+
+        const match = !query || text.includes(query);
+        item.style.display = match ? '' : 'none';
+        if (match) visibleInSection++;
+      });
+
+      const sectionHidden = visibleInSection === 0;
+      list.style.display = sectionHidden ? 'none' : '';
+      if (heading && heading.tagName === 'H2') {
+        heading.style.display = sectionHidden ? 'none' : '';
+      }
+      totalVisible += visibleInSection;
+    });
+
+    noResults.style.display = totalVisible === 0 && query ? 'block' : 'none';
   });
 });
 </script>


### PR DESCRIPTION
## Summary
- Adds a client-side search/filter input to the tools listing page, matching the blog page's Quarto filter style (right-aligned, same Bootstrap classes, font, and theme)
- Filters tools in real-time across names, taglines, and full descriptions
- Hides entire category sections when all their tools are filtered out, with a "no results" message
- Removes redundant intro text (already covered by page description)

🤖 Generated with [Claude Code](https://claude.com/claude-code)