### PR TITLE
Refocus Base64 tool on image workflows

### DIFF
--- a/tools/base64.html
+++ b/tools/base64.html
@@ -351,32 +351,6 @@
             letter-spacing: 0.04em;
         }
 
-        /* MIME input */
-        .mime-row {
-            display: flex;
-            align-items: center;
-            gap: 8px;
-            margin-bottom: 10px;
-            font-size: 12px;
-            color: var(--text-muted);
-        }
-
-        .mime-input {
-            background: var(--bg-inset);
-            border: 1px solid var(--border);
-            border-radius: 6px;
-            padding: 5px 10px;
-            font-size: 12px;
-            color: var(--text-content);
-            font-family: "SF Mono", "Fira Code", "Fira Mono", Menlo, Consolas, monospace;
-            outline: none;
-            transition: border-color 0.15s;
-            width: 200px;
-        }
-
-        .mime-input:focus {
-            border-color: var(--accent);
-        }
     </style>
 </head>
 <body>
@@ -387,13 +361,13 @@
         </header>
 
         <div class="tab-bar">
-            <button class="tab-btn active" onclick="switchTab('text')">Text</button>
-            <button class="tab-btn" onclick="switchTab('file-encode')">File → Base64</button>
-            <button class="tab-btn" onclick="switchTab('file-decode')">Base64 → File</button>
+            <button class="tab-btn active" onclick="switchTab('file-decode')">Base64 → Image</button>
+            <button class="tab-btn" onclick="switchTab('file-encode')">Image → Base64</button>
+            <button class="tab-btn" onclick="switchTab('text')">Text</button>
         </div>
 
         <!-- TEXT TAB -->
-        <div id="tab-text" class="tab-panel active">
+        <div id="tab-text" class="tab-panel">
             <div class="toolbar-row">
                 <span class="group-label">Mode:</span>
                 <button id="textBtnEncode" class="ctrl-btn active" onclick="setTextMode('encode')">Encode</button>
@@ -426,16 +400,16 @@
             </div>
         </div>
 
-        <!-- FILE → BASE64 TAB -->
+        <!-- IMAGE → BASE64 TAB -->
         <div id="tab-file-encode" class="tab-panel">
             <div id="fileEncodeError" class="error-msg"></div>
 
             <div class="drop-zone" id="encodeDropZone" onclick="document.getElementById('encodeFileInput').click()">
-                <div class="drop-zone-icon">📂</div>
-                <div class="drop-zone-text">Drop any file here</div>
-                <div class="drop-zone-sub">or click to browse</div>
+                <div class="drop-zone-icon">🖼️</div>
+                <div class="drop-zone-text">Drop an image here</div>
+                <div class="drop-zone-sub">or click to browse · PNG, JPEG, WebP, GIF</div>
             </div>
-            <input type="file" id="encodeFileInput" class="file-input">
+            <input type="file" id="encodeFileInput" class="file-input" accept="image/*">
 
             <div id="fileMeta" class="file-meta">
                 <span><strong id="fileName">—</strong></span>
@@ -443,54 +417,50 @@
                 <span>Type: <strong id="fileType">—</strong></span>
             </div>
 
+            <div id="encodeImgPreview" class="img-preview">
+                <img id="encodePreviewImg" src="" alt="Preview">
+            </div>
+
             <div class="panel">
                 <div class="panel-header">
-                    <span class="panel-label">Base64 Output</span>
+                    <span class="panel-label">Data URI Output</span>
                     <div class="toolbar">
                         <button class="ctrl-btn" onclick="copyFrom('encodeOutput', this)">Copy</button>
                         <button class="ctrl-btn" onclick="clearFileEncode()">Clear</button>
                     </div>
                 </div>
-                <textarea id="encodeOutput" placeholder="Base64 will appear here after selecting a file…" readonly spellcheck="false"></textarea>
+                <textarea id="encodeOutput" placeholder="data:image/png;base64,… will appear here after selecting an image" readonly spellcheck="false"></textarea>
             </div>
         </div>
 
-        <!-- BASE64 → FILE TAB -->
-        <div id="tab-file-decode" class="tab-panel">
+        <!-- BASE64 → IMAGE TAB -->
+        <div id="tab-file-decode" class="tab-panel active">
             <div id="fileDecodeError" class="error-msg"></div>
-
-            <div class="mime-row">
-                <label for="mimeInput">MIME type (optional):</label>
-                <input type="text" id="mimeInput" class="mime-input" placeholder="e.g. image/png" spellcheck="false">
-                <span style="color:var(--text-dim);font-size:11px;">auto-detected from data URI prefix</span>
-            </div>
 
             <div class="split-pane">
                 <div class="panel">
                     <div class="panel-header">
-                        <span class="panel-label">Base64 Input</span>
+                        <span class="panel-label">Base64 / Data URI Input</span>
                         <div class="toolbar">
                             <button class="ctrl-btn" onclick="clearFileDecode()">Clear</button>
                         </div>
                     </div>
-                    <textarea id="decodeInput" placeholder="Paste base64 string or data URI here…" spellcheck="false"></textarea>
+                    <textarea id="decodeInput" placeholder="Paste base64 string or data:image/… URI here…" spellcheck="false"></textarea>
                 </div>
                 <div class="panel">
                     <div class="panel-header">
-                        <span class="panel-label">Preview / Download</span>
+                        <span class="panel-label">Preview</span>
+                        <div class="toolbar">
+                            <button class="ctrl-btn" id="downloadImgBtn" onclick="downloadImage()" style="display:none">Download</button>
+                        </div>
                     </div>
                     <div id="imgPreview" class="img-preview">
-                        <div class="img-preview-label">Image Preview</div>
                         <img id="previewImg" src="" alt="Preview">
                     </div>
                     <div id="decodeStatus" style="font-size:13px;color:var(--text-muted);margin-top:8px;flex:1;display:flex;align-items:center;justify-content:center;">
-                        Decoded file will appear here
+                        Paste a base64 image to preview
                     </div>
                 </div>
-            </div>
-
-            <div class="action-row">
-                <button class="ctrl-btn primary" onclick="decodeFile()">Decode &amp; Download</button>
             </div>
         </div>
     </div>
@@ -619,16 +589,18 @@
             hideError('fileEncodeError');
             const reader = new FileReader();
             reader.onload = () => {
-                // result is data URL: data:<mime>;base64,<data>
                 const dataUrl = reader.result;
-                const b64 = dataUrl.split(',')[1];
-                document.getElementById('encodeOutput').value = b64;
+                document.getElementById('encodeOutput').value = dataUrl;
 
-                const meta = document.getElementById('fileMeta');
                 document.getElementById('fileName').textContent = file.name;
                 document.getElementById('fileSize').textContent = formatBytes(file.size);
                 document.getElementById('fileType').textContent = file.type || 'unknown';
-                meta.classList.add('visible');
+                document.getElementById('fileMeta').classList.add('visible');
+
+                const preview = document.getElementById('encodeImgPreview');
+                const img = document.getElementById('encodePreviewImg');
+                img.src = dataUrl;
+                preview.classList.add('visible');
             };
             reader.onerror = () => showError('fileEncodeError', 'Failed to read file.');
             reader.readAsDataURL(file);
@@ -637,99 +609,91 @@
         function clearFileEncode() {
             document.getElementById('encodeOutput').value = '';
             document.getElementById('fileMeta').classList.remove('visible');
+            document.getElementById('encodeImgPreview').classList.remove('visible');
+            document.getElementById('encodePreviewImg').src = '';
             encodeFileInput.value = '';
             hideError('fileEncodeError');
         }
 
-        // ─── BASE64 → FILE TAB ──────────────────────────────────────────────────
+        // ─── BASE64 → IMAGE TAB ─────────────────────────────────────────────────
         const decodeInput = document.getElementById('decodeInput');
 
-        // Auto-detect MIME from data URI prefix as user types
+        function buildDataUri(val) {
+            const trimmed = val.trim();
+            if (!trimmed) return null;
+            if (trimmed.startsWith('data:')) return trimmed;
+            // Try to detect image type from magic bytes and build a data URI
+            const cleaned = trimmed.replace(/\s/g, '');
+            const sigs = [
+                { prefix: 'iVBORw0K', mime: 'image/png' },
+                { prefix: '/9j/', mime: 'image/jpeg' },
+                { prefix: 'R0lGOD', mime: 'image/gif' },
+                { prefix: 'UklGR', mime: 'image/webp' },
+            ];
+            for (const sig of sigs) {
+                if (cleaned.startsWith(sig.prefix)) return `data:${sig.mime};base64,${cleaned}`;
+            }
+            return null;
+        }
+
         let decodeTimer;
         decodeInput.addEventListener('input', () => {
             clearTimeout(decodeTimer);
-            decodeTimer = setTimeout(() => {
-                const val = decodeInput.value.trim();
-                if (val.startsWith('data:')) {
-                    const match = val.match(/^data:([^;]+);base64,/);
-                    if (match) document.getElementById('mimeInput').value = match[1];
-                }
-            }, 300);
+            decodeTimer = setTimeout(updateImagePreview, 300);
         });
 
-        function isValidBase64(str) {
-            return /^[A-Za-z0-9+/]*={0,2}$/.test(str) && str.length % 4 === 0;
-        }
-
-        function decodeFile() {
+        function updateImagePreview() {
             hideError('fileDecodeError');
-            let raw = decodeInput.value.trim();
-            if (!raw) { showError('fileDecodeError', 'Paste a base64 string first.'); return; }
-
-            let mime = document.getElementById('mimeInput').value.trim() || 'application/octet-stream';
-            let b64 = raw;
-
-            // Strip data URI prefix if present
-            if (raw.startsWith('data:')) {
-                const match = raw.match(/^data:([^;]+);base64,(.+)$/s);
-                if (match) {
-                    mime = match[1];
-                    b64 = match[2];
-                    document.getElementById('mimeInput').value = mime;
-                } else {
-                    showError('fileDecodeError', 'Invalid data URI format.');
-                    return;
-                }
-            }
-
-            // Validate
-            const cleaned = b64.replace(/\s/g, '');
-            if (!isValidBase64(cleaned)) {
-                showError('fileDecodeError', 'Invalid base64 string — check for non-base64 characters or incorrect padding.');
-                return;
-            }
-
-            let binary;
-            try {
-                binary = atob(cleaned);
-            } catch (e) {
-                showError('fileDecodeError', 'Decode error: ' + e.message);
-                return;
-            }
-
-            const bytes = new Uint8Array(binary.length);
-            for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i);
-
-            const blob = new Blob([bytes], { type: mime });
-            const url = URL.createObjectURL(blob);
-
-            // Image preview
+            const dataUri = buildDataUri(decodeInput.value);
             const imgPreview = document.getElementById('imgPreview');
             const previewImg = document.getElementById('previewImg');
-            if (mime.startsWith('image/')) {
-                previewImg.src = url;
-                imgPreview.classList.add('visible');
-            } else {
+            const statusEl = document.getElementById('decodeStatus');
+            const downloadBtn = document.getElementById('downloadImgBtn');
+
+            if (!dataUri) {
                 imgPreview.classList.remove('visible');
+                previewImg.src = '';
+                downloadBtn.style.display = 'none';
+                statusEl.textContent = 'Paste a base64 image to preview';
+                statusEl.style.color = 'var(--text-muted)';
+                return;
             }
 
-            // Download
-            const ext = mime.split('/')[1] || 'bin';
-            const a = document.createElement('a');
-            a.href = url;
-            a.download = 'decoded.' + ext;
-            a.click();
+            previewImg.onload = () => {
+                imgPreview.classList.add('visible');
+                downloadBtn.style.display = '';
+                statusEl.textContent = `✓ ${previewImg.naturalWidth} × ${previewImg.naturalHeight} px`;
+                statusEl.style.color = 'var(--green)';
+            };
+            previewImg.onerror = () => {
+                imgPreview.classList.remove('visible');
+                downloadBtn.style.display = 'none';
+                if (decodeInput.value.trim().length > 10) {
+                    showError('fileDecodeError', 'Could not render image — check the base64 string.');
+                }
+                statusEl.textContent = 'Paste a base64 image to preview';
+                statusEl.style.color = 'var(--text-muted)';
+            };
+            previewImg.src = dataUri;
+        }
 
-            const statusEl = document.getElementById('decodeStatus');
-            statusEl.textContent = `✓ Decoded ${formatBytes(bytes.length)} · ${mime}`;
-            statusEl.style.color = 'var(--green)';
+        function downloadImage() {
+            const dataUri = buildDataUri(decodeInput.value);
+            if (!dataUri) return;
+            const match = dataUri.match(/^data:([^;]+);base64,/);
+            const ext = match ? match[1].split('/')[1] : 'png';
+            const a = document.createElement('a');
+            a.href = dataUri;
+            a.download = `image.${ext}`;
+            a.click();
         }
 
         function clearFileDecode() {
             decodeInput.value = '';
-            document.getElementById('mimeInput').value = '';
             document.getElementById('imgPreview').classList.remove('visible');
-            document.getElementById('decodeStatus').textContent = 'Decoded file will appear here';
+            document.getElementById('previewImg').src = '';
+            document.getElementById('downloadImgBtn').style.display = 'none';
+            document.getElementById('decodeStatus').textContent = 'Paste a base64 image to preview';
             document.getElementById('decodeStatus').style.color = 'var(--text-muted)';
             hideError('fileDecodeError');
         }

--- a/tools/index.qmd
+++ b/tools/index.qmd
@@ -128,10 +128,10 @@ Convert between YAML and JSON with live validation, configurable indentation, fi
 :::
 
 ::: {.tool-item}
-[Base64 Encoder/Decoder](base64.html){.tool-link} [encode/decode text and binary files]{.tool-tagline}
+[Base64 Encoder/Decoder](base64.html){.tool-link} [encode/decode images and text]{.tool-tagline}
 
 ::: {.tool-desc}
-Encode and decode base64 in three modes: live text, file-to-base64 (drag-and-drop), and base64-to-file with image preview and download.
+Decode base64 to image with live preview and download, encode images to base64 data URIs (drag-and-drop), or encode/decode plain text.
 :::
 :::
 


### PR DESCRIPTION
## Summary

- Rename File↔Base64 tabs to Image↔Base64, restrict file input to images only
- Image → Base64 now outputs full data URI (`data:image/png;base64,…`) instead of raw base64
- Base64 → Image shows live preview as you paste, download button appears on success, no MIME field needed
- Auto-detect image type from base64 magic bytes (PNG/JPEG/WebP/GIF)
- Reorder tabs: Base64 → Image (default/highlighted), Image → Base64, Text
- Update tool tagline and description in the tools index

🤖 Generated with [Claude Code](https://claude.com/claude-code)