### PR TITLE
fix: correct publication title for 2019 SEG paper

### DIFF
--- a/publications.qmd
+++ b/publications.qmd
@@ -50,7 +50,7 @@ Garg, A., Vos, A., Bortych, N., Gupta, D. K., Verschuur, D. J.
 
 ::: {.publication-item}
 ::: {.pub-title}
-Spatial aliasing removal using deep learning super-resolution
+Estimation of reservoir elastic parameters via full-wavefield redatuming: Comparison of approaches
 :::
 ::: {.pub-authors}
 Garg, A., Verschuur, D. J.


### PR DESCRIPTION
## Summary

- Corrected wrong title on 2019 SEG conference paper entry in `publications.qmd`
- Was: *Spatial aliasing removal using deep learning super-resolution* (duplicate of the First Break journal entry above)
- Now: *Estimation of reservoir elastic parameters via full-wavefield redatuming: Comparison of approaches*
- The DOI link was already correct; only the display title was wrong

🤖 Generated with [Claude Code](https://claude.com/claude-code)