### PR TITLE
Update home, about, and blog copy to reflect builder identity

### DIFF
--- a/about.qmd
+++ b/about.qmd
@@ -4,9 +4,9 @@ sidebar: false
 toc: true
 ---
 
-I am a Senior ML Engineer who builds and ships production generative AI systems, from AI workflows and image enhancement pipelines to multi-agent systems. I bridge deep research expertise with hands-on engineering to build AI products that drive real business impact.
+I am a Senior ML Engineer specializing in computer vision and LLMs. I ship production generative AI systems and on the side rebuild them from scratch to understand how they really work. I bridge deep research expertise with hands-on engineering to build AI products that drive real business impact.
 
-Currently, I am working as a Senior Machine Learning Engineer at [Jiffy](https://www.jiffy.com/), where I build and maintain the core image enhancement pipeline, architect multi-agent systems for AI-powered image editing, and develop end-to-end ML solutions spanning VLM fine-tuning, custom model deployment on RunPod/Replicate and LLM-powered automation across verticals.
+Currently, I am working as a Senior Machine Learning Engineer at [Jiffy](https://www.jiffy.com/) where I build the AI image enhancement pipeline powering a $100M+ DTF printing business, architect Smart Redraw (a multi-agent AI editing system), and develop end-to-end ML solutions spanning LLM fine-tuning, custom model deployment on RunPod/Replicate and LLM-powered automation.
 
 Previously at [Flixstock](https://www.flixstock.com/), I integrated the HuggingFace ecosystem as core ML infrastructure and built Stable Diffusion pipelines for background generation, identity transfer with pose control and fashion video generation.
 
@@ -31,7 +31,7 @@ Jan 2024 - Present
 Senior Machine Learning Engineer
 :::
 ::: {.card-description}
-Built and maintained the core image enhancement pipeline, Smart Redraw (a multi-agent AI editing system), and end-to-end ML solutions spanning VLM fine-tuning, custom model deployment and LLM-powered automation.
+Built and maintained the core image enhancement pipeline, Smart Redraw (a multi-agent AI editing system) and ML solutions spanning fine-tuning, model deployment and LLM-powered automation.
 :::
 :::
 
@@ -48,7 +48,7 @@ Aug 2022 - Dec 2023
 Software Development Engineer III
 :::
 ::: {.card-description}
-Built Stable Diffusion pipelines for background generation, identity transfer, and fashion video generation.
+Built Stable Diffusion pipelines for background generation, identity transfer and video generation.
 :::
 :::
 

--- a/blog/index.qmd
+++ b/blog/index.qmd
@@ -1,6 +1,6 @@
 ---
 title: "Blogs"
-description: "All posts on ML engineering, LLMs, and AI products."
+description: "From-scratch LLM builds, deep-dives and practical AI engineering."
 sidebar: false
 toc: false
 listing:

--- a/index.qmd
+++ b/index.qmd
@@ -1,6 +1,6 @@
 ---
 title: "Aayush Garg"
-description: "LLM fundamentals, fine-tuning experiments, and building reliable AI systems."
+description: "ML engineer who ships production AI systems and rebuilds LLMs from first principles."
 sidebar: false
 toc: true
 listing:
@@ -26,21 +26,21 @@ format:
 
 ![](static/img/aayush_cropped.jpg){.profile-pic fig-alt="Aayush Garg"}
 
-I am a Senior ML Engineer who builds and ships production generative AI systems, from image enhancement pipelines to multi-agent systems. At Jiffy, I build the core image enhancement pipeline, architect multi-agent editing systems and deploy custom ML/LLM models at scale.
+I am a Senior ML Engineer specializing in computer vision and LLMs. At Jiffy, I build the AI image enhancement pipeline powering a $100M+ DTF printing business and Smart Redraw, a multi-agent image editing system. Outside work, I build the full LLM stack from first principles and write about it here.
 
 :::
 
 ## 💼 Current Work
 
-I work at the intersection of computer vision and LLMs, building production AI systems that drive business impact. My background in computational geophysics keeps me grounded in first principles and pragmatic experimentation.
+I work at the intersection of computer vision and LLMs, building production AI systems. On the side, I am building the full LLM stack from scratch: BPE tokenizers, GPT-2 pretraining, SFT and GRPO alignment. My background in research and computational geophysics keeps me drawn to understanding things from first principles.
 
-If you're interested in my work or want to collaborate, feel free to reach out via [email](mailto:aayushgargiitr@gmail.com) or connect on [LinkedIn](https://www.linkedin.com/in/aayush-garg-8b26a734) or [Twitter](https://twitter.com/Aayush_ander).
+If you are interested in my work or want to collaborate, feel free to reach out via [email](mailto:aayushgargiitr@gmail.com) or connect on [LinkedIn](https://www.linkedin.com/in/aayush-garg-8b26a734) or [Twitter](https://twitter.com/Aayush_ander).
 
 ---
 
 ## 📮 Blog
 
-I write about LLM fundamentals, fine-tuning experiments, and building reliable AI systems. Below are my recent posts.
+I write about LLMs, concepts deep-dives and practical AI engineering. Below are my recent posts.
 
 ::: {#blog-listings}
 :::


### PR DESCRIPTION
## Summary

- Rework tagline, intro paragraphs, and blog descriptions across homepage, about page, and blog listing to highlight the from-scratch LLM building focus alongside production AI work
- Add $100M+ pipeline and Smart Redraw details to Jiffy descriptions
- Update blog description to match actual content: from-scratch builds, deep-dives, and practical AI engineering

🤖 Generated with [Claude Code](https://claude.com/claude-code)