### PR TITLE
Add RSS feed icon to navbar

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -46,6 +46,8 @@ website:
         href: "https://www.linkedin.com/in/aayush-garg-8b26a734"
       - icon: twitter
         href: "https://twitter.com/Aayush_ander"
+      - icon: rss
+        href: "https://garg-aayush.github.io/blog/index.xml"
   page-footer:
     center:
       - icon: github


### PR DESCRIPTION
## Summary
- Added RSS icon to the navbar right side, alongside GitHub, LinkedIn, and Twitter icons
- Points to `https://garg-aayush.github.io/blog/index.xml` (already generated by Quarto)

🤖 Generated with [Claude Code](https://claude.com/claude-code)