### PR TITLE
Refine blog categories to topic-based system

### DIFF
--- a/posts/2024-05-19-manage-multiple-cuda.qmd
+++ b/posts/2024-05-19-manage-multiple-cuda.qmd
@@ -1,7 +1,7 @@
 ---
 title:  Managing multiple CUDA versions using environment modules in Ubuntu
 tags: ["gpu", "cuda", "nvidia", 'module']
-categories: [Tools & Dev]
+categories: [Tools & Infra]
 mathjax: true
 description: Guide to install CUDA locally and manage multiple cuda environments on Ubuntu GPU server.
 date: 2024-05-19

--- a/posts/2024-06-30-remote-gpu-server.qmd
+++ b/posts/2024-06-30-remote-gpu-server.qmd
@@ -1,7 +1,7 @@
 ---
 title:  Step-by-Step Guide to Setup Your Personal GPU Server
 tags: ["gpu","ngrok", "openssh"]
-categories: [Tools & Dev]
+categories: [Tools & Infra]
 mathjax: true
 description: Guide to set up a remotely accessible personal GPU Ubuntu server, enabling its access from anywhere.
 date: 2024-06-30

--- a/posts/2024-07-03-baseline-gpt4o-structured-data.qmd
+++ b/posts/2024-07-03-baseline-gpt4o-structured-data.qmd
@@ -1,7 +1,7 @@
 ---
 title:  "Part I: Baseline Evaluation of GPT-4o for Functional Representation Extraction"
 tags: ["LLMs", "GPT", "Evaluation", "VIGGO"]
-categories: [Fine-tuning]
+categories: [LLM Evaluation]
 mathjax: true
 description: This blog gives a detailed walkthrough of structured data extraction using OpenAI's GPT-4o model.
 date: 2024-07-03

--- a/posts/2024-07-09-compare-models-structured-data.qmd
+++ b/posts/2024-07-09-compare-models-structured-data.qmd
@@ -1,7 +1,7 @@
 ---
 title:  "Part II: Comparison of Model Performances on Structured Functional Representation Extraction"
 tags: ["LLMs", "GPT", "Evaluation", "ViGGO", "Claude", "Llama", "Gemini", "Mistral"]
-categories: [Fine-tuning]
+categories: [LLM Evaluation]
 mathjax: true
 description: This blog post compares the performance of various models in extracting structured functional representations from text.
 date: 2024-07-09

--- a/posts/2024-07-15-finetune-llama3-8B-predibase.qmd
+++ b/posts/2024-07-15-finetune-llama3-8B-predibase.qmd
@@ -1,7 +1,7 @@
 ---
 title:  "Part III: Fine-tuning Llama-3-8B for Structured Functional Representation Extraction"
 tags: ["LLMs", "Finetuning", "Predibase", "ViGGO", "Llama", "LORA"]
-categories: [Fine-tuning]
+categories: [LLM Training]
 mathjax: true
 description: Blog on fine-tuning a Llama-3-8B model on the Predibase platform for structured functional representation extraction, and compare its performance with GPT-4 and Claude 3.5 Sonnet.
 date: 2024-07-15

--- a/posts/2025-09-08-building-gpt-from-scratch.qmd
+++ b/posts/2025-09-08-building-gpt-from-scratch.qmd
@@ -1,7 +1,7 @@
 ---
 title: "Building GPT from Scratch: Following Karpathy's Tutorial"
 tags: ["GPT", "Transformers", "PyTorch", "Deep Learning"]
-categories: [From Scratch]
+categories: [Transformers]
 mathjax: false
 description: This blog summarizes building the GPT architecture by following Andrej Karpathy's 'Let's Build GPT' tutorial.
 date: 2025-09-08

--- a/posts/2025-09-10-build-custom-comfyui-node.qmd
+++ b/posts/2025-09-10-build-custom-comfyui-node.qmd
@@ -1,7 +1,7 @@
 ---
 title:  "A Guide to Building Custom Nodes in ComfyUI"
 tags: ["ComfyUI", "SVG", "Image Processing"]
-categories: [Tools & Dev]
+categories: [Tools & Infra]
 mathjax: false
 description: A practical guide to quickly building custom ComfyUI nodes. Here I use my SVG2Raster node package as an example.
 date: 2025-09-10

--- a/posts/2025-12-25-deriving-ppo-loss.qmd
+++ b/posts/2025-12-25-deriving-ppo-loss.qmd
@@ -1,7 +1,7 @@
 ---
 title: "Deriving the PPO Loss from First Principles"
 tags: ["Reinforcement Learning", "PPO", "RLHF", "LLMs"]
-categories: [RL & Alignment, From Scratch]
+categories: [RL & Alignment]
 mathjax: true
 description: A step-by-step derivation of the Proximal Policy Optimization (PPO) loss, starting from basic RL concepts and building up to the complete RLHF objective used in LLM alignment.
 date: 2025-12-25

--- a/posts/2025-12-28-sft-from-scratch.qmd
+++ b/posts/2025-12-28-sft-from-scratch.qmd
@@ -1,7 +1,7 @@
 ---
 title: "What I Learned Building SFT from the Ground Up"
 tags: ["LLMs", "Fine-tuning", "SFT", "Qwen", "Llama"]
-categories: [Fine-tuning, From Scratch]
+categories: [LLM Training]
 mathjax: false
 description: A hands-on journey implementing SFT from scratch, covering reasoning SFT with Qwen2.5-Math and instruction SFT with Llama-3.1-8B, along with debugging lessons learned.
 date: 2025-12-03

--- a/posts/2025-12-30-deriving-dpo-loss.qmd
+++ b/posts/2025-12-30-deriving-dpo-loss.qmd
@@ -1,7 +1,7 @@
 ---
 title: "Deriving the DPO Loss from First Principles"
 tags: ["Reinforcement Learning", "DPO", "RLHF", "LLMs"]
-categories: [RL & Alignment, From Scratch]
+categories: [RL & Alignment]
 mathjax: true
 description: A step-by-step derivation of the Direct Preference Optimization (DPO) loss, showing how it reformulates the RLHF objective into a simple classification loss without requiring explicit reward modeling or reinforcement learning.
 date: 2025-12-30

--- a/posts/2026-01-06-review-deepseek-math.qmd
+++ b/posts/2026-01-06-review-deepseek-math.qmd
@@ -1,7 +1,7 @@
 ---
 title: "Key Insights from DeepSeekMath paper"
 tags: ["Reinforcement Learning", "GRPO", "RLHF", "LLMs", "Math"]
-categories: [RL & Alignment, Paper Notes]
+categories: [Paper Notes]
 mathjax: false
 description: Notes and takeaways from the DeepSeekMath paper including a deep dive into their iterative data curation pipeline
 date: 2026-01-06

--- a/posts/2026-01-13-claude-skills/index.qmd
+++ b/posts/2026-01-13-claude-skills/index.qmd
@@ -1,7 +1,7 @@
 ---
 title: "A Brief Introduction to Claude Agent Skills"
 tags: ["Claude", "Agent Skills", "AI Agents", "LLMs"]
-categories: [Tools & Dev]
+categories: [Tools & Infra]
 mathjax: false
 description: A practical guide to Claude Skills, what they are, why they matter and how to build your own using a basic image editing skill as an example.
 date: 2026-01-13

--- a/posts/2026-01-23-expert-iteration/index.qmd
+++ b/posts/2026-01-23-expert-iteration/index.qmd
@@ -1,7 +1,7 @@
 ---
 title: "Expert Iteration for Math Reasoning"
 tags: ["Expert Iteration", "LLMs", "Reasoning", "Reinforcement Learning"]
-categories: [RL & Alignment]
+categories: [RL & Alignment, LLM Training]
 mathjax: true
 description: Blogpost discussing experiments with Expert Iteration for math reasoning, covering hyperparameter tuning, training dynamics and comparison with SFT.
 date: 2026-01-23

--- a/posts/2026-02-12-cc-tools/index.qmd
+++ b/posts/2026-02-12-cc-tools/index.qmd
@@ -1,7 +1,7 @@
 ---
 title: "Tools for Better Claude Code and Terminal Experience"
 tags: ["CLI Tools", "Claude Code", "LLMs", "Developer Tools"]
-categories: [Tools & Dev]
+categories: [Tools & Infra]
 mathjax: false
 description: A handful of simple tools and practices that have stuck with me while using Claude Code and other AI coding assistants, from tracking usage and managing context to terminal upgrades and the llm CLI.
 date: 2026-02-12

--- a/posts/2026-03-20-browser-tools/index.qmd
+++ b/posts/2026-03-20-browser-tools/index.qmd
@@ -1,7 +1,7 @@
 ---
 title: "Building Browser Tools with Claude Code"
 tags: ["Tools", "AI-Assisted Development", "Claude Code", "Web Development"]
-categories: [Tools & Dev]
+categories: [Tools & Infra]
 mathjax: false
 description: "Introducing the browser-based tools section on my website, client-side utilities for images, data, and viewing, built almost entirely with Claude Code."
 date: 2026-03-20

--- a/posts/2026-03-27-flash-attention/index.qmd
+++ b/posts/2026-03-27-flash-attention/index.qmd
@@ -1,7 +1,7 @@
 ---
 title: "FlashAttention: Making Attention I/O-Aware"
 tags: ["FlashAttention", "LLMs", "Transformers", "GPU", "Attention"]
-categories: [Paper Notes]
+categories: [Transformers]
 mathjax: true
 description: "Understanding FlashAttention from first principles: how operator fusion, tiling, recomputation, and online softmax make attention IO-aware"
 date: 2026-03-27


### PR DESCRIPTION
## Summary
- Refined blog categories from 6 approach-based to 7 topic-based categories
- Removed "From Scratch" (described approach, not topic) and "Fine-tuning" (too broad)
- Added "Transformers", "LLM Evaluation", renamed "Tools & Dev" to "Tools & Infra"
- Moved ViGGO Parts I & II from Fine-tuning to LLM Evaluation where they belong

🤖 Generated with [Claude Code](https://claude.com/claude-code)