### PR TITLE
Weather: align title with map, fix Quarto auto-placement squeezing the leaderboard

### DIFF
--- a/india-weather.qmd
+++ b/india-weather.qmd
@@ -28,14 +28,14 @@ include-after-body:
       <div id="iw-status" class="iw-status">Loading map...</div>
     </div>
 
-    <aside class="iw-leaderboard" aria-label="City rankings">
+    <div class="iw-leaderboard" role="complementary" aria-label="City rankings">
       <div class="iw-tabs" role="tablist">
         <button class="iw-tab iw-active" type="button" data-tab="hottest" role="tab">Hottest</button>
         <button class="iw-tab" type="button" data-tab="worst-air" role="tab">Worst air</button>
         <button class="iw-tab" type="button" data-tab="humid" role="tab">Most humid</button>
       </div>
       <ul id="iw-leaderboard-list" class="iw-list"></ul>
-    </aside>
+    </div>
   </div>
 
   <section class="iw-history" aria-label="History charts">

--- a/static/india-weather/india-weather.css
+++ b/static/india-weather/india-weather.css
@@ -1,5 +1,16 @@
 /* India Weather page styles. Reuses CSS vars from styles.css. */
 
+/* Quarto auto-injects `page-columns page-full` onto top-level divs in raw HTML
+   blocks under page-layout: full, then auto-places children in the page-columns
+   slots — map ends up in body-content (narrower than the title) and the
+   leaderboard in the right page margin (~215px). Force our two rows back to
+   the column-page slot so they line up with the title and span the full page
+   width. */
+.iw-root.page-columns > .iw-meta,
+.iw-root.page-columns > .iw-grid {
+  grid-column: page-start / page-end !important;
+}
+
 .iw-root {
   margin-top: 0.25rem;
 }
@@ -19,11 +30,18 @@
   letter-spacing: 0.01em;
 }
 
-.iw-grid {
-  display: grid;
-  grid-template-columns: minmax(0, 1fr) clamp(380px, 30%, 460px);
+.iw-grid,
+.iw-grid.page-columns,
+.iw-grid.page-columns.page-full {
+  display: grid !important;
+  grid-template-columns: minmax(0, 1fr) clamp(380px, 30%, 460px) !important;
   gap: 1rem;
   align-items: stretch;
+}
+/* Quarto's page-columns rule otherwise places the leaderboard in the right
+   margin column instead of the second cell of our template. */
+.iw-grid > * {
+  grid-column: auto !important;
 }
 
 .iw-map-wrap {


### PR DESCRIPTION
## Summary
- Quarto's \`page-layout: full\` was auto-injecting \`page-columns page-full\` classes onto our top-level divs and treating \`<aside>\` as margin content, which placed the map in the narrower body-content slot (x≈248) and shoved the leaderboard into the right page margin (~215px wide). The title meanwhile sat at column-page (x≈152), so the title looked offset to the left of everything else and the leaderboard stayed cramped no matter what \`grid-template-columns\` we set.
- Switch the leaderboard from \`<aside>\` to \`<div>\` so Quarto stops auto-placing it in the right margin column.
- Force \`.iw-meta\` and \`.iw-grid\` back to the column-page slot, and re-declare the \`.iw-grid\` template (\`1fr / clamp(380px, 30%, 460px)\`) with \`!important\` so it wins over Quarto's injected \`page-columns\` rule. Reset children to \`grid-column: auto\` so they auto-flow into our two cells.
- Net effect: title, meta, map and leaderboard all share the same left edge, and the leaderboard widens from 215px to 380–460px.

🤖 Generated with [Claude Code](https://claude.com/claude-code)