### PR TITLE
Weather: leader-line markers and tighter India-only pan bounds

### DIFF
--- a/india-weather.qmd
+++ b/india-weather.qmd
@@ -1,6 +1,6 @@
 ---
 title: "How's the weather across India right now?"
-description: "Live temperature, humidity, and air quality across India's major metropolitan cities. Refreshed every ~15 minutes."
+description: "Live temperature, humidity, and air quality across India's major metropolitan cities."
 page-layout: full
 toc: false
 sidebar: false

--- a/static/india-weather/india-weather.css
+++ b/static/india-weather/india-weather.css
@@ -180,30 +180,76 @@
   margin-top: 2px;
 }
 
-/* Mapbox markers */
+/* Mapbox markers: dot at the geo point, pill offset to a chosen anchor,
+   leader line connecting them. The marker root itself is a 0x0 anchor — all
+   visual size lives in absolutely-positioned children. */
 .iw-marker {
+  position: absolute;
+  width: 0;
+  height: 0;
+  pointer-events: none;
+}
+
+.iw-marker-dot {
+  position: absolute;
+  left: -5px;
+  top: -5px;
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  background: var(--accent);
+  border: 2px solid #fff;
+  box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.55), 0 1px 3px rgba(0, 0, 0, 0.4);
+  pointer-events: auto;
+  cursor: pointer;
+  z-index: 2;
+}
+
+.iw-marker-leader {
+  position: absolute;
+  left: 0;
+  top: 0;
+  z-index: 1;
+  pointer-events: none;
+}
+
+.iw-marker-leader line {
+  stroke: rgba(255, 255, 255, 0.55);
+  stroke-width: 1;
+}
+
+.iw-marker-pill {
+  position: absolute;
+  left: 0;
+  top: 0;
   background: var(--bg-secondary);
   color: var(--text-primary);
   border: 1px solid var(--accent);
-  border-radius: 14px;
-  padding: 3px 8px;
-  font-size: 0.78rem;
+  border-radius: 12px;
+  padding: 2px 7px;
+  font-size: 0.74rem;
   font-weight: 600;
   font-variant-numeric: tabular-nums;
   white-space: nowrap;
   cursor: pointer;
-  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.35);
-  transition: transform 120ms, border-color 120ms;
+  pointer-events: auto;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.4);
+  transition: border-color 120ms;
+  z-index: 2;
 }
 
-.iw-marker:hover {
-  transform: translateY(-1px);
+.iw-marker-pill:hover {
   border-color: var(--text-primary);
 }
 
-.iw-marker .iw-marker-temp {
+.iw-marker-pill .iw-marker-temp {
   color: var(--accent);
   margin-left: 4px;
+}
+
+.iw-marker-pill.iw-hidden,
+.iw-marker-leader.iw-hidden {
+  display: none;
 }
 
 /* Mapbox popup overrides for dark theme */

--- a/static/india-weather/india-weather.js
+++ b/static/india-weather/india-weather.js
@@ -137,12 +137,149 @@
     ].join('');
   }
 
-  function markerHtml(city) {
+  // -- Marker layout --------------------------------------------------------
+  //
+  // Each marker is a 0x0 wrapper anchored at the city's lng/lat. Inside we
+  // render three layers:
+  //   - a small dot at the wrapper origin (the actual geo pin),
+  //   - an SVG leader from the dot to a chosen anchor point,
+  //   - a label pill (name + temp) translated to that anchor point.
+  //
+  // ANCHOR_OFFSETS maps a compass anchor to the pill's offset (x, y) from the
+  // dot, plus the percentage shift (tx, ty) that aligns the pill's anchored
+  // edge with that point. CITY_ANCHORS hand-curates a preferred anchor order
+  // for cities in the cluttered NCR cluster; everything else falls back to a
+  // generic order. relayoutMarkers() walks cities in priority order and picks
+  // the first anchor whose pill bbox doesn't collide with already-placed
+  // pills; pills with no free anchor are hidden (the dot still shows).
+  const ANCHOR_OFFSETS = {
+    ne: { x:  14, y: -10, tx: '0',     ty: '-100%' },
+    nw: { x: -14, y: -10, tx: '-100%', ty: '-100%' },
+    se: { x:  14, y:  10, tx: '0',     ty: '0' },
+    sw: { x: -14, y:  10, tx: '-100%', ty: '0' },
+    e:  { x:  16, y:   0, tx: '0',     ty: '-50%' },
+    w:  { x: -16, y:   0, tx: '-100%', ty: '-50%' },
+    n:  { x:   0, y: -16, tx: '-50%',  ty: '-100%' },
+    s:  { x:   0, y:  16, tx: '-50%',  ty: '0' },
+  };
+
+  const CITY_ANCHORS = {
+    delhi:     ['ne', 'n', 'nw'],
+    gurugram:  ['sw', 's', 'w'],
+    ghaziabad: ['e', 'se', 'ne'],
+    noida:     ['se', 's', 'e'],
+  };
+  const DEFAULT_ANCHORS = ['ne', 'e', 'se', 'sw', 'w', 'nw', 'n', 's'];
+
+  function pillContents(city) {
     const t = city.weather && city.weather.temperature_c != null
       ? Math.round(city.weather.temperature_c) + '°'
       : '—';
     return '<span class="iw-marker-name">' + city.name + '</span>'
       + '<span class="iw-marker-temp">' + t + '</span>';
+  }
+
+  function buildMarkerElement(city) {
+    const root = document.createElement('div');
+    root.className = 'iw-marker';
+    root.title = city.name;
+
+    const leader = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+    leader.setAttribute('class', 'iw-marker-leader');
+    leader.setAttribute('width', '1');
+    leader.setAttribute('height', '1');
+    leader.setAttribute('overflow', 'visible');
+    const line = document.createElementNS('http://www.w3.org/2000/svg', 'line');
+    line.setAttribute('x1', '0');
+    line.setAttribute('y1', '0');
+    line.setAttribute('x2', '0');
+    line.setAttribute('y2', '0');
+    leader.appendChild(line);
+
+    const pill = document.createElement('div');
+    pill.className = 'iw-marker-pill';
+    pill.innerHTML = pillContents(city);
+
+    const dot = document.createElement('span');
+    dot.className = 'iw-marker-dot';
+
+    root.appendChild(leader);
+    root.appendChild(pill);
+    root.appendChild(dot);
+
+    return { root, leader, line, pill, dot };
+  }
+
+  function applyAnchor(entry, anchor) {
+    const off = ANCHOR_OFFSETS[anchor];
+    if (!off) return;
+    entry.pill.style.transform =
+      'translate(' + off.x + 'px, ' + off.y + 'px) translate(' + off.tx + ', ' + off.ty + ')';
+    entry.line.setAttribute('x2', String(off.x));
+    entry.line.setAttribute('y2', String(off.y));
+    entry.currentAnchor = anchor;
+  }
+
+  function rectsOverlap(a, b) {
+    return !(a.right <= b.left || a.left >= b.right || a.bottom <= b.top || a.top >= b.bottom);
+  }
+
+  function padRect(r, pad) {
+    return { left: r.left - pad, right: r.right + pad, top: r.top - pad, bottom: r.bottom + pad };
+  }
+
+  // Re-runs after every map move/zoom (rAF-coalesced) and after data updates.
+  // Cities are sorted hottest-first so the highest-priority labels claim
+  // their preferred anchor; cooler cities yield. Pills with no clear slot
+  // hide their pill+leader -- the dot stays visible so the city is still
+  // findable via hover or click.
+  function relayoutMarkers() {
+    if (!lastData || cityState.size === 0) return;
+    const sorted = lastData.cities.slice().sort((a, b) => {
+      const ta = (a.weather && a.weather.temperature_c != null) ? a.weather.temperature_c : -Infinity;
+      const tb = (b.weather && b.weather.temperature_c != null) ? b.weather.temperature_c : -Infinity;
+      return tb - ta;
+    });
+
+    const placed = [];
+    for (const city of sorted) {
+      const entry = cityState.get(city.id);
+      if (!entry) continue;
+      const anchors = CITY_ANCHORS[city.id] || DEFAULT_ANCHORS;
+
+      entry.pill.classList.remove('iw-hidden');
+      entry.leader.classList.remove('iw-hidden');
+
+      let chosen = null;
+      let chosenRect = null;
+      for (const a of anchors) {
+        applyAnchor(entry, a);
+        const rect = entry.pill.getBoundingClientRect();
+        const padded = padRect(rect, 3);
+        if (placed.every(r => !rectsOverlap(padded, r))) {
+          chosen = a;
+          chosenRect = padded;
+          break;
+        }
+      }
+
+      if (chosen == null) {
+        entry.pill.classList.add('iw-hidden');
+        entry.leader.classList.add('iw-hidden');
+      } else {
+        placed.push(chosenRect);
+      }
+    }
+  }
+
+  let relayoutScheduled = false;
+  function scheduleRelayout() {
+    if (relayoutScheduled) return;
+    relayoutScheduled = true;
+    requestAnimationFrame(() => {
+      relayoutScheduled = false;
+      relayoutMarkers();
+    });
   }
 
   function leaderboardSorters() {
@@ -208,19 +345,17 @@
     for (const city of data.cities) {
       let entry = cityState.get(city.id);
       if (!entry) {
-        const el = document.createElement('div');
-        el.className = 'iw-marker';
-        el.innerHTML = markerHtml(city);
+        const parts = buildMarkerElement(city);
         const popup = new mapboxgl.Popup({ offset: 18, closeButton: true, maxWidth: '300px' })
           .setHTML(popupHtml(city));
-        const marker = new mapboxgl.Marker({ element: el, anchor: 'center' })
+        const marker = new mapboxgl.Marker({ element: parts.root, anchor: 'center' })
           .setLngLat([city.lon, city.lat])
           .setPopup(popup)
           .addTo(map);
-        entry = { marker, popup, el };
+        entry = Object.assign({ marker, popup, el: parts.root }, parts);
         cityState.set(city.id, entry);
       } else {
-        entry.el.innerHTML = markerHtml(city);
+        entry.pill.innerHTML = pillContents(city);
         entry.popup.setHTML(popupHtml(city));
       }
     }
@@ -231,6 +366,7 @@
       );
       map.fitBounds(bounds, { padding: 50, maxZoom: 5.5, duration: 0 });
     }
+    scheduleRelayout();
   }
 
   function renderUpdated(data) {
@@ -795,6 +931,8 @@
         setStatus(null);
         if (lastData) ensureMarkers(lastData);
       });
+      map.on('move', scheduleRelayout);
+      map.on('zoom', scheduleRelayout);
       map.on('error', (e) => {
         const msg = (e && e.error && e.error.message) || 'Unknown error';
         if (msg.toLowerCase().includes('access token')) {

--- a/static/india-weather/india-weather.js
+++ b/static/india-weather/india-weather.js
@@ -777,16 +777,17 @@
     }
     mapboxgl.accessToken = MAPBOX_TOKEN;
     try {
-      // Camera is locked to the Indian subcontinent. minZoom keeps the user
-      // from zooming out past the default Indian view; maxBounds keeps panning
-      // inside the same region so the camera can't drift over empty ocean.
+      // Camera is pinned to India. maxBounds tracks the country's actual
+      // bbox (~68-97.5 E, ~6-37.5 N) with a tiny pad so coastlines aren't
+      // clipped, and minZoom matches the initial zoom so the user can never
+      // scroll out to see neighbouring countries or the open ocean.
       map = new mapboxgl.Map({
         container: 'iw-map',
         style: 'mapbox://styles/mapbox/dark-v11',
         center: [80.0, 22.5],
         zoom: 3.8,
         minZoom: 3.8,
-        maxBounds: [[60, 5], [100, 38]],
+        maxBounds: [[67, 5.5], [98, 37.5]],
         attributionControl: true,
       });
       map.addControl(new mapboxgl.NavigationControl({ showCompass: false }), 'top-right');


### PR DESCRIPTION
## Summary

- Drop the `Refreshed every ~15 minutes` tail from the page description; the relative `Updated Nm ago` timestamp already conveys this and is more accurate when the cron drifts.
- Tighten the map's `maxBounds` from `[60, 5]/[100, 38]` to `[67, 5.5]/[98, 37.5]` so a fast pan can no longer drift past India's coastline into Iran, Tibet, or the deep Bay of Bengal.
- Redesign the city markers: each city is now a small dot at the precise geo point + a name/temp pill offset to a chosen compass anchor + an SVG leader line connecting them. Hand-curated anchors fan the Delhi / Gurugram / Ghaziabad cluster apart, and a runtime collision pass (rAF-coalesced on map move/zoom, hottest-first priority) hides any pill that has no free anchor — the dot stays visible so the city is still findable via hover or click.

🤖 Generated with [Claude Code](https://claude.com/claude-code)