### PR TITLE
Weather: tighten 24h AQI flip criterion (coverage + recency)

### DIFF
--- a/static/india-weather/india-weather.js
+++ b/static/india-weather/india-weather.js
@@ -735,11 +735,24 @@
       const hourly = hourlyCache.get(cityId);
       const points = (hourly && Array.isArray(hourly.points_24h)) ? hourly.points_24h : [];
       // Prefer WAQI/CPCB stations (matches the live tile) once the rolling
-      // window has accumulated them. Falls back to CAMS during the 24h
-      // warm-up after rollout, or if WAQI was blocked across the window.
-      const hasWaqi = points.some(p => p && p.aqi_waqi != null && Number.isFinite(p.aqi_waqi));
-      const aqiKey = hasWaqi ? 'aqi_waqi' : 'aqi';
-      setAqiSourceLabel(hasWaqi ? 'waqi' : 'cams');
+      // window has enough of them. Two guards:
+      //   coverage >= 75%  - kills premature flips during the warm-up. The
+      //                      old "any single point" rule would flip on the
+      //                      first WAQI run and show one dot with 95 nulls
+      //                      around it. Also auto-reverts to CAMS if WAQI
+      //                      stays dead for hours and the proportion drops.
+      //   recent point     - kills the case where WAQI was healthy for 18h
+      //                      then died; without this we'd label the chart
+      //                      "CPCB" while its right edge is hours stale.
+      // Falls back to CAMS when either guard fails.
+      const total = points.length;
+      const withWaqi = points.filter(p => p && p.aqi_waqi != null && Number.isFinite(p.aqi_waqi)).length;
+      const coverage = total > 0 ? withWaqi / total : 0;
+      const latest = points[points.length - 1];
+      const recentHasWaqi = !!(latest && latest.aqi_waqi != null && Number.isFinite(latest.aqi_waqi));
+      const useWaqi = coverage >= 0.75 && recentHasWaqi;
+      const aqiKey = useWaqi ? 'aqi_waqi' : 'aqi';
+      setAqiSourceLabel(useWaqi ? 'waqi' : 'cams');
       renderLineChart('aqi',  'iw-chart-aqi',      'AQI',      '#75A8D9',
         v => Math.round(v),                points, aqiKey);
       renderLineChart('temp', 'iw-chart-temp',     'Temp',     '#E8A87C',


### PR DESCRIPTION
## Summary
- Replace the over-eager "any single \`aqi_waqi\` point flips the chart" rule with **coverage ≥ 75 % AND most-recent point has WAQI**.
- Old rule would have shown a 24h chart with one dot on the right edge and ~95 nulls during the warm-up; new rule waits until the chart actually has shape before flipping.
- Also auto-reverts to CAMS if WAQI dies for hours (coverage drops below threshold) or if the latest point is WAQI-less (latest-edge guard).
- At 15-min Worker cadence, time-to-flip after rollout is ~18 h (72 of 96 points need to land). That's deliberate: soon enough to matter, late enough that the chart looks like a chart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)