### PR TITLE
India Weather: default 24h history picker to Delhi

### DIFF
--- a/static/india-weather/india-weather.js
+++ b/static/india-weather/india-weather.js
@@ -283,7 +283,8 @@
       .map(c => '<option value="' + c.id + '">' + c.name + '</option>')
       .join('');
     if (!activeHistoryCity) {
-      activeHistoryCity = sorted[0].id;
+      const preferred = sorted.find(c => c.id === 'delhi');
+      activeHistoryCity = (preferred || sorted[0]).id;
       elHistoryCity.value = activeHistoryCity;
       loadAndRenderHistory(activeHistoryCity);
     }


### PR DESCRIPTION
## Summary
- The 24h history section's city dropdown defaulted to the alphabetically first city (Ahmedabad). Switched the default to Delhi, with a fallback to `sorted[0]` if Delhi isn't in `cities.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)