### PR TITLE
Mobile-friendly fixes: profile pic, navbar, blog listing, tables

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -26,7 +26,7 @@ website:
     title: false
     background: dark
     pinned: true
-    collapse: false
+    collapse: true
     left:
       - text: Home
         href: index.qmd

--- a/styles.css
+++ b/styles.css
@@ -136,7 +136,7 @@
   }
 }
 
-@media (max-width: 480px) {
+@media (max-width: 640px) {
   #blog-listings table,
   #blog-listings thead,
   #blog-listings tbody,
@@ -145,39 +145,33 @@
   #blog-listings tr {
     display: block;
   }
-  
+
   #blog-listings thead tr {
     position: absolute;
     top: -9999px;
     left: -9999px;
   }
-  
+
   #blog-listings tr {
-    margin-bottom: 1rem;
+    margin-bottom: 0.5rem;
+    padding: 0.75rem 0;
     border-bottom: 1px solid var(--border-color);
   }
-  
+
   #blog-listings td {
     border: none;
-    position: relative;
-    padding-left: 40%;
-    text-align: right;
-  }
-  
-  #blog-listings td:before {
-    position: absolute;
-    left: 6px;
-    width: 35%;
-    white-space: nowrap;
+    padding: 0.15rem 0;
     text-align: left;
-    font-weight: bold;
   }
-  
-  #blog-listings td:nth-of-type(1):before {
-    content: "Date";
+
+  #blog-listings td:nth-of-type(1) {
+    font-size: 0.8rem;
+    color: var(--text-muted);
   }
-  #blog-listings td:nth-of-type(2):before {
-    content: "Title";
+
+  #blog-listings td:nth-of-type(2) a {
+    font-size: 1rem;
+    line-height: 1.35;
   }
 }
 

--- a/styles.css
+++ b/styles.css
@@ -250,6 +250,18 @@ pre {
   padding: 1rem;
 }
 
+/* Wide tables in posts: scroll horizontally on phones instead of squeezing
+   columns into 3-letter slivers. Excludes the blog listing (which is its own
+   styled card layout on mobile). */
+@media (max-width: 768px) {
+  main table:not(.quarto-listing-table) {
+    display: block;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+    max-width: 100%;
+  }
+}
+
 /* Blockquote styling */
 blockquote {
   border-left: 4px solid var(--accent);

--- a/styles.css
+++ b/styles.css
@@ -85,8 +85,11 @@
   margin-bottom: 1rem;
 }
 
-/* Blog listings - table style */
-#blog-listings {
+/* Blog listings - table style.
+   Quarto renders the listing into #listing-<id> (e.g. #listing-blog-listings),
+   not the raw id used in the page frontmatter, so we target the table class
+   directly. */
+.quarto-listing-container-table {
   margin-top: 1.5rem;
   width: 100%;
   overflow-x: auto;
@@ -126,50 +129,50 @@
 
 /* Responsive table for mobile */
 @media (max-width: 768px) {
-  #blog-listings table {
+  .quarto-listing-table {
     font-size: 0.9rem;
   }
-  
-  #blog-listings th,
-  #blog-listings td {
+
+  .quarto-listing-table th,
+  .quarto-listing-table td {
     padding: 0.5rem;
   }
 }
 
 @media (max-width: 640px) {
-  #blog-listings table,
-  #blog-listings thead,
-  #blog-listings tbody,
-  #blog-listings th,
-  #blog-listings td,
-  #blog-listings tr {
+  .quarto-listing-table,
+  .quarto-listing-table thead,
+  .quarto-listing-table tbody,
+  .quarto-listing-table th,
+  .quarto-listing-table td,
+  .quarto-listing-table tr {
     display: block;
   }
 
-  #blog-listings thead tr {
+  .quarto-listing-table thead tr {
     position: absolute;
     top: -9999px;
     left: -9999px;
   }
 
-  #blog-listings tr {
+  .quarto-listing-table tr {
     margin-bottom: 0.5rem;
     padding: 0.75rem 0;
     border-bottom: 1px solid var(--border-color);
   }
 
-  #blog-listings td {
+  .quarto-listing-table td {
     border: none;
     padding: 0.15rem 0;
     text-align: left;
   }
 
-  #blog-listings td:nth-of-type(1) {
+  .quarto-listing-table td:nth-of-type(1) {
     font-size: 0.8rem;
     color: var(--text-muted);
   }
 
-  #blog-listings td:nth-of-type(2) a {
+  .quarto-listing-table td:nth-of-type(2) a {
     font-size: 1rem;
     line-height: 1.35;
   }

--- a/styles.css
+++ b/styles.css
@@ -39,7 +39,9 @@
 }
 
 @media (max-width: 600px) {
-  .profile-pic {
+  /* Higher specificity than `.content img` further down so the hide actually wins. */
+  .profile-header .quarto-figure,
+  .profile-header .profile-pic {
     display: none;
   }
 }


### PR DESCRIPTION
## Summary

Five focused CSS / config fixes that make the site genuinely usable on phones, verified at 390x844 in Chromium.

- **Profile pic hidden on mobile.** The existing `@media (max-width: 600px) { .profile-pic { display: none } }` rule lost the cascade to `.content img { display: block }` defined later. The cropped headshot rendered ~312px tall on phones, dominating the homepage. Scoped the hide rule under `.profile-header` to bump specificity and target the figure so no whitespace remains.
- **Navbar collapses to a hamburger.** `collapse: false` forced the full nav inline on phones, where "Weather" was cut mid-word and Publications/About fell off the right edge. Flipped to `true`.
- **Blog listing selector was stale.** Every `#blog-listings` CSS rule has been a no-op since the file was written, because Quarto renders the listing into `#listing-blog-listings` (prefixed id). Switched all rules to target `.quarto-listing-table` directly, so the responsive layout actually applies.
- **Blog listing card layout up to 640px.** Was 480px (below typical phone widths); also simplified the card to a small muted date above the title rather than the fragile absolute-positioned Date: pseudo-prefix.
- **Wide tables in posts scroll horizontally on mobile.** The Qwen vs Gemma table previously squeezed columns into 3-letter slivers with mid-word header wraps. `display: block; overflow-x: auto;` under 768px, excluding the listing table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)