### PR TITLE
Update site for Applied Computing ML-FDE role

### DIFF
--- a/about.qmd
+++ b/about.qmd
@@ -6,7 +6,9 @@ toc: true
 
 I am a Senior ML Engineer specializing in computer vision and LLMs. I ship production generative AI systems and on the side rebuild them from scratch to understand how they really work. I bridge deep research expertise with hands-on engineering to build AI products that drive real business impact.
 
-Currently, I am working as a Senior Machine Learning Engineer at [Jiffy](https://www.jiffy.com/) where I build the AI image enhancement pipeline powering a $100M+ DTF printing business, architect Smart Redraw (a multi-agent AI editing system), and develop end-to-end ML solutions spanning LLM fine-tuning, custom model deployment on RunPod/Replicate and LLM-powered automation.
+Currently, I am an ML Engineer (Forward Deployed) at [Applied Computing](https://appliedcomputing.com/), where I deploy, tune, and operationalise Orbital, a physics-informed foundation model for energy operations, inside live industrial environments spanning cloud, on-premise, hybrid, and air-gapped infrastructure.
+
+Before that, at [Jiffy](https://www.jiffy.com/), I built the AI image enhancement pipeline powering a $100M+ DTF printing business, architected Smart Redraw (a multi-agent AI editing system), and developed end-to-end ML solutions spanning LLM fine-tuning, custom model deployment on RunPod/Replicate and LLM-powered automation.
 
 Previously at [Flixstock](https://www.flixstock.com/), I integrated the HuggingFace ecosystem as core ML infrastructure and built Stable Diffusion pipelines for background generation, identity transfer with pose control and fashion video generation.
 
@@ -21,10 +23,27 @@ I love connecting and collaborating with new people. Please don't hesitate to re
 ::: {.experience-card}
 ::: {.card-header}
 ::: {.company-name}
+Applied Computing
+:::
+::: {.card-date}
+May 2026 - Present
+:::
+:::
+::: {.card-role}
+ML Engineer (Forward Deployed)
+:::
+::: {.card-description}
+Deploy and tune Orbital's AI systems (time-series forecasting, anomaly detection, multi-agent copilots and RAG pipelines) inside live energy operations across cloud, on-prem, and air-gapped infrastructure.
+:::
+:::
+
+::: {.experience-card}
+::: {.card-header}
+::: {.company-name}
 Jiffy
 :::
 ::: {.card-date}
-Jan 2024 - Present
+Jan 2024 - Mar 2026
 :::
 :::
 ::: {.card-role}

--- a/index.qmd
+++ b/index.qmd
@@ -26,13 +26,13 @@ format:
 
 ![](static/img/aayush_cropped.jpg){.profile-pic fig-alt="Aayush Garg"}
 
-I am a Senior ML Engineer specializing in computer vision and LLMs. At Jiffy, I build the AI image enhancement pipeline powering a $100M+ DTF printing business and Smart Redraw, a multi-agent image editing system. Outside work, I build the full LLM stack from first principles and write about it here.
+I am an ML Engineer (Forward Deployed) at Applied Computing, where I deploy and tune Orbital, a physics-informed foundation model for energy operations, inside live industrial environments. Previously at Jiffy, I built the AI image enhancement pipeline powering a $100M+ DTF printing business and Smart Redraw, a multi-agent image editing system. Outside work, I build the full LLM stack from first principles and write about it here.
 
 :::
 
 ## 💼 Current Work
 
-I work at the intersection of computer vision and LLMs, building production AI systems. On the side, I am building the full LLM stack from scratch: BPE tokenizers, GPT-2 pretraining, SFT and GRPO alignment. My background in research and computational geophysics keeps me drawn to understanding things from first principles.
+At Applied Computing, I deploy, tune, and operationalise Orbital's AI systems (time-series forecasting, anomaly detection, multi-agent copilots and RAG pipelines) inside live energy operations spanning cloud, on-premise, and air-gapped infrastructure. On the side, I am building the full LLM stack from scratch: BPE tokenizers, GPT-2 pretraining, SFT and GRPO alignment. My background in research and computational geophysics keeps me drawn to understanding things from first principles.
 
 If you are interested in my work or want to collaborate, feel free to reach out via [email](mailto:aayushgargiitr@gmail.com) or connect on [LinkedIn](https://www.linkedin.com/in/aayush-garg-8b26a734) or [Twitter](https://twitter.com/Aayush_ander).
 


### PR DESCRIPTION
## Summary
- Homepage: profile blurb and Current Work section now lead with the ML Engineer (Forward Deployed) role at Applied Computing (deploying/tuning Orbital), with Jiffy demoted to a previous role
- About: Applied Computing added as the current role in the intro and experience grid (May 2026 - Present); Jiffy end date set to Mar 2026

🤖 Generated with [Claude Code](https://claude.com/claude-code)