### PR TITLE
Refresh Applied Computing bio

### DIFF
--- a/about.qmd
+++ b/about.qmd
@@ -4,9 +4,11 @@ sidebar: false
 toc: true
 ---
 
-I am a Senior ML Engineer specializing in computer vision and LLMs. I ship production generative AI systems and on the side rebuild them from scratch to understand how they really work. I bridge deep research expertise with hands-on engineering to build AI products that drive real business impact.
+I build production AI systems for complex industrial operations. My work combines machine learning, product engineering, and customer delivery, taking solutions from an initially ambiguous operating problem through modelling, validation, deployment, and production support.
 
-Currently, I am an ML Engineer (Forward Deployed) at [Applied Computing](https://appliedcomputing.com/), where I deploy, tune, and operationalise Orbital, a physics-informed foundation model for energy operations, inside live industrial environments spanning cloud, on-premise, hybrid, and air-gapped infrastructure.
+Currently, I am a Forward Deployed ML Engineer at [Applied Computing](https://appliedcomputing.com/), working on decision systems for refineries and energy operations. I collaborate directly with process engineers and operators to turn plant data, engineering knowledge, and operational constraints into forecasting, anomaly detection, and optimisation capabilities that fit real workflows.
+
+My background spans computational geophysics, industrial research, computer vision, generative AI, and production ML. That combination helps me move between scientific problems, software systems, and the practical realities of deploying technology for customers.
 
 Before that, at [Jiffy](https://www.jiffy.com/), I built the AI image enhancement pipeline powering a $100M+ DTF printing business, architected Smart Redraw (a multi-agent AI editing system), and developed end-to-end ML solutions spanning LLM fine-tuning, custom model deployment on RunPod/Replicate and LLM-powered automation.
 
@@ -26,14 +28,14 @@ I love connecting and collaborating with new people. Please don't hesitate to re
 Applied Computing
 :::
 ::: {.card-date}
-May 2026 - Present
+May 2026 to Present
 :::
 :::
 ::: {.card-role}
 ML Engineer (Forward Deployed)
 :::
 ::: {.card-description}
-Deploy and tune Orbital's AI systems (time-series forecasting, anomaly detection, multi-agent copilots and RAG pipelines) inside live energy operations across cloud, on-prem, and air-gapped infrastructure.
+Build and deliver production AI systems for refinery and energy operations, working directly with process engineers and operators from problem framing and industrial data integration through model validation, deployment, and production support. Translate plant constraints and customer feedback into forecasting, anomaly detection, and optimisation capabilities that industrial teams can understand and trust.
 :::
 :::
 

--- a/index.qmd
+++ b/index.qmd
@@ -1,6 +1,6 @@
 ---
 title: "Aayush Garg"
-description: "ML engineer who ships production AI systems and rebuilds LLMs from first principles."
+description: "Forward Deployed ML Engineer building production AI systems for refineries and energy operations."
 sidebar: false
 toc: true
 listing:
@@ -26,13 +26,13 @@ format:
 
 ![](static/img/aayush_cropped.jpg){.profile-pic fig-alt="Aayush Garg"}
 
-I am an ML Engineer (Forward Deployed) at Applied Computing, where I deploy and tune Orbital, a physics-informed foundation model for energy operations, inside live industrial environments. Previously at Jiffy, I built the AI image enhancement pipeline powering a $100M+ DTF printing business and Smart Redraw, a multi-agent image editing system. Outside work, I build the full LLM stack from first principles and write about it here.
+I am a Forward Deployed ML Engineer at Applied Computing, where I build and deliver production AI systems for refineries and energy operations. I work with process engineers and operators to turn plant data, physics, and operating constraints into forecasting, anomaly detection, and optimisation tools they can understand, trust, and act on. Previously at Jiffy, I built the AI image enhancement pipeline powering a $100M+ DTF printing business and Smart Redraw, a multi-agent image editing system. Outside work, I rebuild modern language models from first principles and write about what I learn.
 
 :::
 
 ## 💼 Current Work
 
-At Applied Computing, I deploy, tune, and operationalise Orbital's AI systems (time-series forecasting, anomaly detection, multi-agent copilots and RAG pipelines) inside live energy operations spanning cloud, on-premise, and air-gapped infrastructure. On the side, I am building the full LLM stack from scratch: BPE tokenizers, GPT-2 pretraining, SFT and GRPO alignment. My background in research and computational geophysics keeps me drawn to understanding things from first principles.
+At Applied Computing, my work spans the full lifecycle of industrial AI delivery. I frame operational problems with customers, integrate historian and engineering data, build and validate models, translate operator feedback into product improvements, and deploy reliable systems into customer-controlled environments. The role sits at the intersection of machine learning, product engineering, process understanding, and technical customer delivery.
 
 If you are interested in my work or want to collaborate, feel free to reach out via [email](mailto:aayushgargiitr@gmail.com) or connect on [LinkedIn](https://www.linkedin.com/in/aayush-garg-8b26a734) or [Twitter](https://twitter.com/Aayush_ander).
 


### PR DESCRIPTION
Refreshes the public bio to emphasize industrial AI delivery from problem framing through production support, customer collaboration, and work across refinery and energy operations.

Verification:

* git diff check passed
* Quarto rendered index.qmd and about.qmd successfully